### PR TITLE
Add BSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ else
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
 	All=clisp ccl ecl sbcl
+	ifeq ($(OSName),freebsd)
+		All=ccl ecl sbcl
+	else ifeq ($(OSName),openbsd)
+		All=clisp ecl sbcl
+	else ifeq ($(OSName),netbsd)
+		All=clisp ecl
+	endif
 endif
 
 #

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,21 @@
 # Identify environment information
 #
 
+FetchCmd=wget
+
 ifeq ($(OS),Windows_NT)
 	OSName=windows
 else ifeq ($(shell uname -s),Darwin)
 	OSName=macos
+else ifeq ($(shell uname -s),FreeBSD)
+	OSName=freebsd
+	FetchCmd=/usr/bin/fetch
+else ifeq ($(shell uname -s),OpenBSD)
+	OSName=openbsd
+	FetchCmd=/usr/bin/ftp
+else ifeq ($(shell uname -s),NetBSD)
+	OSName=netbsd
+	FetchCmd=/usr/bin/ftp -o $(KernelArchiveName)
 else
 	OSName=linux
 endif
@@ -96,8 +107,8 @@ ifeq ($(OSName),windows)
 	$(PS) "if (Test-Path kernel) { Remove-Item kernel -Recurse -Force -ErrorAction Ignore }"
 	$(PS) "Rename-Item $(KernelFolderName) kernel -ErrorAction Ignore"
 else
-	wget $(KernelArchiveUrl)
-	tar xf $(KernelArchiveName)
+	$(FetchCmd) $(KernelArchiveUrl)
+	tar zxf $(KernelArchiveName)
 	rm -f $(KernelArchiveName)
 	rm -rf kernel
 	mv $(KernelFolderName) kernel

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,21 @@
 # Identify environment information
 #
 
+FetchCmd=wget
+
 ifeq ($(OS),Windows_NT)
 	OSName=windows
 else ifeq ($(shell uname -s),Darwin)
 	OSName=macos
 else ifeq ($(shell uname -s),FreeBSD)
 	OSName=freebsd
+	FetchCmd=/usr/bin/fetch
 else ifeq ($(shell uname -s),OpenBSD)
 	OSName=openbsd
+	FetchCmd=/usr/bin/ftp
 else ifeq ($(shell uname -s),NetBSD)
 	OSName=netbsd
+	FetchCmd=/usr/bin/ftp -o $(KernelArchiveName)
 else
 	OSName=linux
 endif
@@ -36,17 +41,14 @@ else
 	Slash=/
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
-
-ifeq ($(OSName),freebsd)
-	All=ccl ecl sbcl
-else ifeq ($(OSName),openbsd)
-	All=clisp ecl sbcl
-else ifeq ($(OSName),netbsd)
-	All=clisp ecl
-else
 	All=clisp ccl ecl sbcl
-endif
-
+	ifeq ($(OSName),freebsd)
+		All=ccl ecl sbcl
+	else ifeq ($(OSName),openbsd)
+		All=clisp ecl sbcl
+	else ifeq ($(OSName),netbsd)
+		All=clisp ecl
+	endif
 endif
 
 #
@@ -112,17 +114,6 @@ ifeq ($(OSName),windows)
 	$(PS) "if (Test-Path kernel) { Remove-Item kernel -Recurse -Force -ErrorAction Ignore }"
 	$(PS) "Rename-Item $(KernelFolderName) kernel -ErrorAction Ignore"
 else
-
-ifeq ($(OSName),freebsd)
-	FetchCmd=/usr/bin/fetch
-else ifeq ($(OSName),openbsd)
-	FetchCmd=/usr/bin/ftp
-else ifeq ($(OSName),netbsd)
-	FetchCmd=/usr/bin/ftp -o $(KernelArchiveName)
-else
-	FetchCmd=wget
-endif
-
 	$(FetchCmd) $(KernelArchiveUrl)
 	tar zxf $(KernelArchiveName)
 	rm -f $(KernelArchiveName)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ else
 	ifeq ($(OSName),freebsd)
 		All=ccl ecl sbcl
 	else ifeq ($(OSName),openbsd)
-		All=clisp ecl sbcl
+		All=ecl sbcl
 	else ifeq ($(OSName),netbsd)
 		All=clisp ecl
 	endif

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,16 @@
 # Identify environment information
 #
 
-FetchCmd=wget
-
 ifeq ($(OS),Windows_NT)
 	OSName=windows
 else ifeq ($(shell uname -s),Darwin)
 	OSName=macos
 else ifeq ($(shell uname -s),FreeBSD)
 	OSName=freebsd
-	FetchCmd=/usr/bin/fetch
 else ifeq ($(shell uname -s),OpenBSD)
 	OSName=openbsd
-	FetchCmd=/usr/bin/ftp
 else ifeq ($(shell uname -s),NetBSD)
 	OSName=netbsd
-	FetchCmd=/usr/bin/ftp -o $(KernelArchiveName)
 else
 	OSName=linux
 endif
@@ -41,14 +36,17 @@ else
 	Slash=/
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
+
+ifeq ($(OSName),freebsd)
+	All=ccl ecl sbcl
+else ifeq ($(OSName),openbsd)
+	All=clisp ecl sbcl
+else ifeq ($(OSName),netbsd)
+	All=clisp ecl
+else
 	All=clisp ccl ecl sbcl
-	ifeq ($(OSName),freebsd)
-		All=ccl ecl sbcl
-	else ifeq ($(OSName),openbsd)
-		All=clisp ecl sbcl
-	else ifeq ($(OSName),netbsd)
-		All=clisp ecl
-	endif
+endif
+
 endif
 
 #
@@ -114,6 +112,17 @@ ifeq ($(OSName),windows)
 	$(PS) "if (Test-Path kernel) { Remove-Item kernel -Recurse -Force -ErrorAction Ignore }"
 	$(PS) "Rename-Item $(KernelFolderName) kernel -ErrorAction Ignore"
 else
+
+ifeq ($(OSName),freebsd)
+	FetchCmd=/usr/bin/fetch
+else ifeq ($(OSName),openbsd)
+	FetchCmd=/usr/bin/ftp
+else ifeq ($(OSName),netbsd)
+	FetchCmd=/usr/bin/ftp -o $(KernelArchiveName)
+else
+	FetchCmd=wget
+endif
+
 	$(FetchCmd) $(KernelArchiveUrl)
 	tar zxf $(KernelArchiveName)
 	rm -f $(KernelArchiveName)

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install
 
 Below is a summary of currently supported implementations per BSD variant. As always, you should check for yourself the availability of these CLs with the package manager of the particular BSD you are running, e.g., `pkg search sbcl` or `pkg_info -Q sbcl`.
 
-|       | FreeBSD            | OpenBSD | NetBSD    |
-|:------|:-------------------|:--------|:----------|
-| CLisp | N/A                | Latest  | Latest    |
-| CCL   | `pkg install ccl`  | N/A     | N/A       |
-| ECL   | `pkg install ecl`  | Latest  | Latest    |
-| SBCL  | `pkg install sbcl` | Recent  | i386 Only |
+|       | FreeBSD            | OpenBSD         | NetBSD                     |
+|:------|:-------------------|:----------------|:---------------------------|
+| CLisp | N/A                | `pkg_add clisp` | `pkg_add clisp`            |
+| CCL   | `pkg install ccl`  | N/A             | N/A                        |
+| ECL   | `pkg install ecl`  | `pkg_add ecl`   | `pkg_add ecl`              |
+| SBCL  | `pkg install sbcl` | `pkg_add sbcl`  | `pkg_add sbcl` (i386 Only) |
 
 Also, you will need to install GNU make. This repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install
 
 ### FreeBSD, OpenBSD and NetBSD
 
-CLisp, ECL and SBCL are available through packages, ports or pkgsrc.
+CLisp, Clozure, ECL and SBCL are available through packages, ports or pkgsrc, with some minor exceptions. (For instance, as of early 2018, Clozure is *only* available for FreeBSD, CLisp is *not* available on FreeBSD, and SBCL is *not* available as a binary package for NetBSD 7.x/8.x amd64, but *is* available for NetBSD 7.x i386.)  As always, you should check for yourself the availability of these CLs with the package manager of the particular BSD you are running, e.g., `pkg search sbcl` or `pkg_info -Q sbcl`.
 
-Also, this repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
+Also, you will need to install GNU make. This repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bug reports, fixes and enhancements are welcome. If you intend to port Shen to a
 
 You will need to have recent versions of the Common Lisp implementations you want to work with installed and available as the `Makefile` requires. Installation is different depending on operating system.
 
-Support for Common Lisp implementations varies over different operating systems. By default, only implementations available in binary form are built with the `make all` command. Check the value of the `All` variable in the `Makefile` by running `make env` to which are supported on your machine.
+Support for Common Lisp implementations varies over different operating systems. By default, only implementations available in binary form are built with the `make all` command. Check the value of the `All` variable in the `Makefile` to see which are supported for your OS and architecture.
 
 Check the project page for any CL implementation to build from source if necessary.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Bug reports, fixes and enhancements are welcome. If you intend to port Shen to a
 
 You will need to have recent versions of the Common Lisp implementations you want to work with installed and available as the `Makefile` requires. Installation is different depending on operating system.
 
+Support for Common Lisp implementations varies over different operating systems. By default, only implementations available in binary form are built with the `make all` command. Check the value of the `All` variable in the `Makefile` by running `make env` to which are supported on your machine.
+
+Check the project page for any CL implementation to build from source if necessary.
+
 ### Linux
 
 CLisp, ECL and SBCL are available through `apt`. Just run `sudo apt install clisp ecl sbcl`.
@@ -28,7 +32,7 @@ ECL requires `libffi-dev` to build, which can also be retrieved through `apt`.
 
 There is a [separately available debian package](http://mr.gy/blog/clozure-cl-deb.html) for Clozure. Download and install with `dpkg -i`.
 
-If the version of SBCL available throught `apt` is too old, a sufficiently new version is [available from debian](http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb).
+If the version of SBCL available throught `apt` is too old, a sufficiently new version is [available from debian](http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.4.2-1_arm64.deb).
 
 ### macOS
 
@@ -36,7 +40,14 @@ CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install
 
 ### FreeBSD, OpenBSD and NetBSD
 
-CLisp, Clozure, ECL and SBCL are available through packages, ports or pkgsrc, with some minor exceptions. (For instance, as of early 2018, Clozure is *only* available for FreeBSD, CLisp is *not* available on FreeBSD, and SBCL is *not* available as a binary package for NetBSD 7.x/8.x amd64, but *is* available for NetBSD 7.x i386.)  As always, you should check for yourself the availability of these CLs with the package manager of the particular BSD you are running, e.g., `pkg search sbcl` or `pkg_info -Q sbcl`.
+Below is a summary of currently supported implementations per BSD variant. As always, you should check for yourself the availability of these CLs with the package manager of the particular BSD you are running, e.g., `pkg search sbcl` or `pkg_info -Q sbcl`.
+
+|       | FreeBSD            | OpenBSD | NetBSD   |
+|:------|:-------------------|:--------|:---------|
+| CLisp | N/A                | Latest  | Latest   |
+| CCL   | `pkg install ccl`  | N/A     | N/A      |
+| ECL   | `pkg install ecl`  | Latest  | Latest   |
+| SBCL  | `pkg install sbcl` | Recent  | x86 Only |
 
 Also, you will need to install GNU make. This repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install
 
 Below is a summary of currently supported implementations per BSD variant. As always, you should check for yourself the availability of these CLs with the package manager of the particular BSD you are running, e.g., `pkg search sbcl` or `pkg_info -Q sbcl`.
 
-|       | FreeBSD            | OpenBSD | NetBSD   |
-|:------|:-------------------|:--------|:---------|
-| CLisp | N/A                | Latest  | Latest   |
-| CCL   | `pkg install ccl`  | N/A     | N/A      |
-| ECL   | `pkg install ecl`  | Latest  | Latest   |
-| SBCL  | `pkg install sbcl` | Recent  | x86 Only |
+|       | FreeBSD            | OpenBSD | NetBSD    |
+|:------|:-------------------|:--------|:----------|
+| CLisp | N/A                | Latest  | Latest    |
+| CCL   | `pkg install ccl`  | N/A     | N/A       |
+| ECL   | `pkg install ecl`  | Latest  | Latest    |
+| SBCL  | `pkg install sbcl` | Recent  | i386 Only |
 
 Also, you will need to install GNU make. This repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ If the version of SBCL available throught `apt` is too old, a sufficiently new v
 
 CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install clisp clozure-cl ecl sbcl`.
 
+### FreeBSD, OpenBSD and NetBSD
+
+CLisp, ECL and SBCL are available through packages, ports or pkgsrc.
+
+Also, this repo's `Makefile` is a GNU make makefile and typing `make ...` is likely to invoke the system make (BSD make) and quit on you harshly, complaining about parsing errors. Hence, it is necessary to ensure that the `gmake` package/port is installed, and replace `make ...` in the instructions below with `gmake ...`.
+
 ### Windows
 
 CLisp has an installer and a zip package on [SoureForge](https://sourceforge.net/projects/clisp/files/clisp/2.49/). You'll have to include `clisp.exe` as well as `libintl-8.dll` and `libreadline6.dll` in on your PATH to ensure the clisp build of shen-cl will run.


### PR DESCRIPTION
Hi!

With these changes, Shen installs a bit easier for FreeBSD, OpenBSD and NetBSD users.  A few notes.

- The fetch command used on the BSDs is not `wget` but rather whatever is available in the base system of each operating system, so that there is no need for the user to install any extra program. (BSD users tend to like to use base as much as possible.)

- BSD tar (also found in base) needs the `z` option to uncompress the kernel sources.  GNU tar apparently doesn't (need to be told) -- it can figure it out.  However, I added the `z` option anyway so that the `tar` command unarchiving the kernel sources can work on the BSDs as well as Linux.  Also, there is another `tar` invocation in `Makefile` that still uses the `z` flag (so, historical use :).

- Could not get around the fact that BSD users need to install GNU make; so, this is now noted in the README.

- Tested on `FreeBSD 11.1-RELEASE-p4 #0 amd64`.  Ran `gmake fetch && gmake sbcl` with success.

- Tested on `OpenBSD 6.2 GENERIC.MP#337 amd64`.  Ran `gmake fetch && gmake sbcl` with success.

- Tested on `NetBSD 8.0_BETA (GENERIC.201712221850Z) amd64`.  Ran `gmake fetch && gmake clisp` with success.

- Tested on `Linux 2.6.32-696.6.3.el6.x86_64 x86_64`.  Ran `gmake fetch && gmake clisp` with success.  (I don't have access to another, newer Linux system.)