### PR TITLE
Overwrote shen.sysfunc? to accept any symbols starting with 'lisp.'

### DIFF
--- a/src/backend.lsp
+++ b/src/backend.lsp
@@ -532,7 +532,8 @@
     (T (simple-error (cn "boolean expected: not ~A~%" X)))))
 
 (DEFUN shen.lisp-prefixed? (Symbol)
-  (AND (SYMBOLP Symbol)
+  (AND (NOT (NULL Symbol))
+       (SYMBOLP Symbol)
        (shen-cl.prefix? (str Symbol) "lisp.")))
 
 (DEFUN shen.lisp-function-name (Symbol)

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -25,10 +25,10 @@
 
 (DEFVAR shen-cl.kernel-sysfunc? (FDEFINITION 'shen.sysfunc?))
 
-(DEFUN shen.sysfunc? (Name)
+(DEFUN shen.sysfunc? (Symbol)
   (or
-    (APPLY shen-cl.kernel-sysfunc? (LIST Name))
-    (IF (AND (NOT (NULL Name)) (shen.lisp-prefixed? Name)) 'true 'false)))
+    (APPLY shen-cl.kernel-sysfunc? (LIST Symbol))
+    (IF (shen.lisp-prefixed? Symbol) 'true 'false)))
 
 (DEFUN shen.pvar? (X)
   (IF (AND (ARRAYP X) (NOT (STRINGP X)) (EQ (SVREF X 0) 'shen.pvar))

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -23,6 +23,13 @@
 ; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+(DEFVAR shen-cl.kernel-sysfunc? (FDEFINITION 'shen.sysfunc?))
+
+(DEFUN shen.sysfunc? (Name)
+  (or
+    (APPLY shen-cl.kernel-sysfunc? (LIST Name))
+    (IF (AND (NOT (NULL Name)) (shen.lisp-prefixed? Name)) 'true 'false)))
+
 (DEFUN shen.pvar? (X)
   (IF (AND (ARRAYP X) (NOT (STRINGP X)) (EQ (SVREF X 0) 'shen.pvar))
     'true


### PR DESCRIPTION
This fixes #16 

Demo:

```shen
(shen.sysfunc? append)       true
(shen.sysfunc? xyz)          false
(shen.sysfunc? lisp.xyz)     true
(shen.sysfunc? lsp.xyz)      false
(shen.sysfunc? lisp)         false
(shen.sysfunc? lisp.)        true
(shen.sysfunc? lisp.append)  true
```

There's a check in the override of `sysfunc?` to see if a `[]` has been passed in - apparently this can happen?

```shen
(lisp.symbolp [])        T
(lisp.symbolp ())        T
(lisp.symbolp lisp.nil)  T
(symbol? [])             false
```

`[]` and `()` become CL's `NIL`, which passes `SYMBOLP` and the [code for the package macro](https://github.com/Shen-Language/shen-sources/blob/407240d49b71453fd0ab2b048b0daec4b26b1616/sources/reader.shen#L469) doesn't check for it, but the [code for the define grammar](https://github.com/Shen-Language/shen-sources/blob/1da01a1e46c4ed1e658b2458b87b20913d1ca101/sources/core.shen#L44) does.