### PR TITLE
Add support for literal code `lisp.` form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Updated to Shen Open Source Kernel 21.0.
 ### Added
 - `make release` command that creates os-specific archive of compiled binaries.
 - `dict.kl` to list of KL imports.
+- `lisp.` form to embed literal Common Lisp code.
 
 ### Changed
 - `cond` now raises an error when no condition is true, instead of returning `[]`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ This port acts as the standard implementation of the Shen language. It is also t
 
 Bug reports, fixes and enhancements are welcome. If you intend to port Shen to another variety of Common Lisp, consider doing so as a pull request to this repo.
 
+## Features
+
+`shen-cl` supports calling underlying Common Lisp functions by prefixing them with `lisp.`.
+
+```
+(lisp.sin 6.28)
+-0.0031853017931379904
+```
+
+Common Lisp code can also be injected inline using the `(lisp. "COMMON LISP SYNTAX")` syntax. The `lisp.` form takes a single string as its argument. Also keep in mind that shen-cl puts Common Lisp into case-sensitive mode where CL functions and symbols are upper-case so they don't conflict with symbols defined for Shen.
+
+```
+(lisp. "(SIN 6.28)")
+-0.0031853017931379904
+
+(lisp "(sin 6.28)")
+The function COMMON-LISP-USER::sin is undefined.
+```
+
+The function `shen-cl.exit` is included, which takes a single integer argument, terminates the process, returning the argument as the exit code.
+
 ## Prerequisites
 
 You will need to have recent versions of the Common Lisp implementations you want to work with installed and available as the `Makefile` requires. Installation is different depending on operating system.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Common Lisp code can also be injected inline using the `(lisp. "COMMON LISP SYNT
 (lisp. "(SIN 6.28)")
 -0.0031853017931379904
 
-(lisp "(sin 6.28)")
+(lisp. "(sin 6.28)")
 The function COMMON-LISP-USER::sin is undefined.
 ```
 

--- a/src/backend.lsp
+++ b/src/backend.lsp
@@ -76,11 +76,11 @@
         (MAPCAR #'(LAMBDA (C) (shen.cond_code Locals C)) (CDR Expr))
         '((T (simple-error "No condition was true"))))))
 
-    ; _ [lisp. Code] -> (if (string? Code)
-    ;                       (protect (READ-FROM-STRING Code))
-    ;                       (simple-error "Argument to lisp. must be a literal string"))
+    ; _ [lisp. Code | More] -> (if (and (string? Code) (empty? More))
+    ;                              (protect (READ-FROM-STRING Code))
+    ;                              (simple-error "Argument to lisp. must be a literal string"))
     ((AND (CONSP Expr) (EQ 'lisp. (CAR Expr)))
-     (IF (STRINGP (CADR Expr))
+     (IF (AND (STRINGP (CADR Expr)) (NULL (CDDR Expr)))
          (READ-FROM-STRING (CADR Expr))
          (simple-error "Argument to lisp. must be a literal string")))
 

--- a/src/backend.lsp
+++ b/src/backend.lsp
@@ -76,6 +76,14 @@
         (MAPCAR #'(LAMBDA (C) (shen.cond_code Locals C)) (CDR Expr))
         '((T (simple-error "No condition was true"))))))
 
+    ; _ [lisp. Code] -> (if (string? Code)
+    ;                       (protect (READ-FROM-STRING Code))
+    ;                       (simple-error "Argument to lisp. must be a literal string"))
+    ((AND (CONSP Expr) (EQ 'lisp. (CAR Expr)))
+     (IF (STRINGP (CADR Expr))
+         (READ-FROM-STRING (CADR Expr))
+         (simple-error "Argument to lisp. must be a literal string")))
+
     ; Params [F | X] ->
     ;   (let Arguments (protect (MAPCAR (/. Y (kl-to-lisp Params Y)) X))
     ;     (optimise-application
@@ -503,7 +511,7 @@
       (NULL (CDDDR Expr)))
      (CONS '>= (CDR Expr)))
 
-    ; [less? X Y] -> [< X Y]    
+    ; [less? X Y] -> [< X Y]
     ((AND
       (CONSP Expr)
       (EQ 'shen.less? (CAR Expr))


### PR DESCRIPTION
As discussed on the mailing list, this adds a `(lisp. "literal code string")` form similar to Shen/Scheme's `scm.` form.

```
(0-) (lisp. ":KEYWORD")
KEYWORD

(1-) (lisp. "NIL")
[]

(2-) (lisp. not-a-string)
Argument to lisp. must be a literal string

(3-) (lisp. "(DEFCLASS article ()
  ((title :ACCESSOR article-title :INITARG NIL)
   (author :ACCESSOR article-author)))")
funex1177
```

I don't know if it should be added or not, this is just a proof of concept.