### PR TITLE
MacOS does not ship with wget, but it DOES always have curl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - `CF-VECTORS` can now compare empty absvectors.
 - Shen code now gets defined in `:SHEN` package instead of `:COMMON-LISP` package.
+- Makefile uses `curl` instead of `wget` on macOS.
 
 ## [2.4.0] - 2018-10-08
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifeq ($(OS),Windows_NT)
 	OSName=windows
 else ifeq ($(shell uname -s),Darwin)
 	OSName=macos
+	FetchCmd=curl -OL
 else ifeq ($(shell uname -s),FreeBSD)
 	OSName=freebsd
 	FetchCmd=/usr/bin/fetch


### PR DESCRIPTION
When I tried `make fetch`, I got an error, because `wget` is not on my Mac. `curl` is there, however, so I changed the `Makefile` to use that on MacOS.