### PR TITLE
Catch toplevel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
   - `*port*` is now a string with a `major.minor.patch` format.
+  - Errors raised when evaluating `--load` and `--eval` arguments now print error and exit with code 1.
 
 ## [2.6.0] - 2017-09-04
 

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -383,7 +383,7 @@
       (PROGN
         (FORMAT T "~%!!! FATAL ERROR: ")
         (shen.toplevel-display-exception E)
-        (FORMAT T "Exiting Shen.~%")
+        (FORMAT T "~%Exiting Shen.~%")
         (cl.exit 1)))))
 
 (DEFUN shen-cl.toplevel ()

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -373,10 +373,18 @@
           (cl.exit -1))))))
 
 (DEFUN shen-cl.toplevel-interpret-args (Args)
-  (IF (CONSP Args)
-    (shen-cl.interpret-args Args)
-    (shen-cl.repl))
-  (cl.exit 0))
+  (trap-error
+    (PROGN
+      (IF (CONSP Args)
+        (shen-cl.interpret-args Args)
+        (shen-cl.repl))
+      (cl.exit 0))
+    (lambda E
+      (PROGN
+        (FORMAT T "~%!!! FATAL ERROR: ")
+        (shen.toplevel-display-exception E)
+        (FORMAT T "Exiting Shen.~%")
+        (cl.exit 1)))))
 
 (DEFUN shen-cl.toplevel ()
   (LET ((*PACKAGE* (FIND-PACKAGE :SHEN)))


### PR DESCRIPTION
When a file is loaded with `-l` command line argument or eval'd with `-e`, uncaught exceptions result in going into the CL debugger. User probably won't know what to do when this happends (I don't) so I just have it print the error and exit with a failure code.