### PR TITLE
Initial changes for kernel 22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+**Updated to Shen Open Source Kernel 22.0**
+
+### Changed
+  - Command-line handling has been replaced by the "launcher" kernel extension.
+  - Added "features" kernel extension.
+
 ## [2.6.1] - 2019-09-17
 
-**Updated to Shen Open Source Kernel 21.2**
 
 ### Changed
   - `*port*` is now a string with a `major.minor.patch` format.

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ RunCCL=$(ShenCCL)
 RunECL=$(ShenECL)
 RunSBCL=$(ShenSBCL)
 
-Tests=-e "(cd \"kernel/tests\")" -l README.shen -l tests.shen
+Tests=eval -e "(cd \"kernel/tests\")" -l README.shen -l tests.shen
 
 ReleaseArchiveName=shen-cl-$(GitVersion)-$(OSName)-prebuilt$(ArchiveSuffix)
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ else
 	Slash=/
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
-	All=clisp ccl ecl sbcl
+	All=clisp ccl sbcl
 	ifeq ($(OSName),freebsd)
 		All=ccl ecl sbcl
 	else ifeq ($(OSName),openbsd)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 # Set shared variables
 #
 
-KernelVersion=21.2
+KernelVersion=22.0
 
 UrlRoot=https://github.com/Shen-Language/shen-sources/releases/download
 KernelTag=shen-$(KernelVersion)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ else
 	Slash=/
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
-	All=clisp ccl sbcl
+	All=clisp ccl ecl sbcl
 	ifeq ($(OSName),freebsd)
 		All=ccl ecl sbcl
 	else ifeq ($(OSName),openbsd)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Shen Version](https://img.shields.io/badge/shen-21.2-blue.svg)](https://github.com/Shen-Language)
+[![Shen Version](https://img.shields.io/badge/shen-22.0-blue.svg)](https://github.com/Shen-Language)
 [![Build Status](https://travis-ci.org/Shen-Language/shen-cl.svg?branch=master)](https://travis-ci.org/Shen-Language/shen-cl)
 
 # Shen for Common Lisp

--- a/README.md
+++ b/README.md
@@ -57,21 +57,32 @@ The `Makefile` automates all build and test operations.
 
 An executable is generated for each platform in its platform-specific output directory under `bin/` (e.g. `bin/sbcl/shen.exe`). Per typical naming conventions, it is named `shen.exe` on Windows systems and just `shen` on Unix-based systems.
 
-Running `shen -h` shows a full listing of command-line options:
+Running `shen --help` shows a full listing of command-line options:
 
-| Option            | Argument(s)   | Effect                                       |
-|:------------------|:--------------|:---------------------------------------------|
-| `-e`, `--eval`    | `EXPR`        | Evaluates EXPR and prints result.            |
-| `-h`, `--help`    |               | Shows this help.                             |
-| `-l`, `--load`    | `FILE`        | Reads and evaluates FILE.                    |
-| `-q`, `--quiet`   |               | Silences interactive output.                 |
-| `-r`, `--repl`    |               | Runs the REPL.                               |
-| `-s`, `--set`     | `KEY` `VALUE` | Evaluates KEY, VALUE and sets as global.     |
-| `-v`, `--version` |               | Prints Shen, shen-cl and CL version numbers. |
+```
+commands:
+    repl
+        Launches the interactive REPL.
+        Default action if no command is supplied.
 
-Options are processed in left-to-right order. By combining options, the command line forms its own simple script which loads code, does environment initialisation and can then go into interactive mode by tacking `-r` on the end.
+    script <FILE> [<ARGS>]
+        Runs the script in FILE. *argv* is set to [FILE | ARGS].
 
-If no options are specified the REPL is started.
+    eval <ARGS>
+        Evaluates expressions and files. ARGS are evaluated from
+        left to right and can be a combination of:
+            -e, --eval <EXPR>
+                Evaluates EXPR and prints result.
+            -l, --load <FILE>
+                Reads and evaluates FILE.
+            -q, --quiet
+                Silences interactive output.
+            -s, --set <KEY> <VALUE>
+                Evaluates KEY, VALUE and sets as global.
+            -r, --repl
+                Launches the interactive REPL after evaluating
+                all the previous expresions.
+```
 
 When starting Shen via `make`, command line arguments can be passed through like this: `make run-sbcl Args="-l init.shen -e (run)"`.
 

--- a/README.md
+++ b/README.md
@@ -59,32 +59,7 @@ An executable is generated for each platform in its platform-specific output dir
 
 Running `shen --help` shows a full listing of command-line options:
 
-```
-commands:
-    repl
-        Launches the interactive REPL.
-        Default action if no command is supplied.
-
-    script <FILE> [<ARGS>]
-        Runs the script in FILE. *argv* is set to [FILE | ARGS].
-
-    eval <ARGS>
-        Evaluates expressions and files. ARGS are evaluated from
-        left to right and can be a combination of:
-            -e, --eval <EXPR>
-                Evaluates EXPR and prints result.
-            -l, --load <FILE>
-                Reads and evaluates FILE.
-            -q, --quiet
-                Silences interactive output.
-            -s, --set <KEY> <VALUE>
-                Evaluates KEY, VALUE and sets as global.
-            -r, --repl
-                Launches the interactive REPL after evaluating
-                all the previous expresions.
-```
-
-When starting Shen via `make`, command line arguments can be passed through like this: `make run-sbcl Args="-l init.shen -e (run)"`.
+When starting Shen via `make`, command line arguments can be passed through like this: `make run-sbcl Args="eval -l init.shen -e (run)"`.
 
 ## Releasing
 

--- a/boot.lsp
+++ b/boot.lsp
@@ -199,6 +199,10 @@
 (import-kl "declarations")
 (import-kl "types")
 (import-kl "t-star")
+(import-kl "init")
+
+(shen.initialise)
+
 (import-lsp "overwrite")
 
 (FMAKUNBOUND 'compile-lsp)

--- a/boot.lsp
+++ b/boot.lsp
@@ -201,6 +201,7 @@
 (import-kl "t-star")
 (import-kl "init")
 (import-kl "extension-features")
+(import-kl "extension-launcher")
 (import-lsp "overwrite")
 
 (shen.initialise)

--- a/boot.lsp
+++ b/boot.lsp
@@ -204,15 +204,16 @@
 (import-kl "extension-launcher")
 (import-lsp "overwrite")
 
-(shen.initialise)
-(shen-cl.initialise)
-(shen.x.features.initialise '(
-  shen/cl
-  #+CLISP shen/cl.clisp
-  #+SBCL  shen/cl.sbcl
-  #+ECL   shen/cl.ecl
-  #+CCL   shen/cl.ccl
-))
+#-ECL
+(PROGN
+ (shen.initialise)
+ (shen-cl.initialise)
+ (shen.x.features.initialise '(
+   shen/cl
+   #+CLISP shen/cl.clisp
+   #+SBCL  shen/cl.sbcl
+   #+CCL   shen/cl.ccl
+ )))
 
 (FMAKUNBOUND 'compile-lsp)
 (FMAKUNBOUND 'import-lsp)

--- a/boot.lsp
+++ b/boot.lsp
@@ -200,10 +200,10 @@
 (import-kl "types")
 (import-kl "t-star")
 (import-kl "init")
+(import-lsp "overwrite")
 
 (shen.initialise)
-
-(import-lsp "overwrite")
+(shen-cl.initialise)
 
 (FMAKUNBOUND 'compile-lsp)
 (FMAKUNBOUND 'import-lsp)

--- a/boot.lsp
+++ b/boot.lsp
@@ -200,10 +200,18 @@
 (import-kl "types")
 (import-kl "t-star")
 (import-kl "init")
+(import-kl "extension-features")
 (import-lsp "overwrite")
 
 (shen.initialise)
 (shen-cl.initialise)
+(shen.x.features.initialise '(
+  shen/cl
+  #+CLISP shen/cl.clisp
+  #+SBCL  shen/cl.sbcl
+  #+ECL   shen/cl.ecl
+  #+CCL   shen/cl.ccl
+))
 
 (FMAKUNBOUND 'compile-lsp)
 (FMAKUNBOUND 'import-lsp)

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -131,14 +131,16 @@
 (DEFUN shen-cl.exit (Code)
   (cl.exit Code))
 
-(put      'cl.exit 'arity 1 *property-vector*)
-(put 'shen-cl.exit 'arity 1 *property-vector*)
+(DEFUN shen-cl.initialise ()
+  (PROGN
+    (put      'cl.exit 'arity 1 *property-vector*)
+    (put 'shen-cl.exit 'arity 1 *property-vector*)
 
-(declare      'cl.exit (LIST 'number '--> 'unit))
-(declare 'shen-cl.exit (LIST 'number '--> 'unit))
+    (declare      'cl.exit (LIST 'number '--> 'unit))
+    (declare 'shen-cl.exit (LIST 'number '--> 'unit))
 
-(shen-cl.read-eval "(defmacro      cl.exit-macro      [cl.exit] -> [cl.exit 0])")
-(shen-cl.read-eval "(defmacro shen-cl.exit-macro [shen-cl.exit] -> [cl.exit 0])")
+    (shen-cl.read-eval "(defmacro      cl.exit-macro      [cl.exit] -> [cl.exit 0])")
+    (shen-cl.read-eval "(defmacro shen-cl.exit-macro [shen-cl.exit] -> [cl.exit 0])")))
 
 #+(OR CCL SBCL)
 (DEFUN shen.read-char-code (S)

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -348,7 +348,7 @@
         (WITH-OPEN-STREAM (*STANDARD-OUTPUT* (EXT:MAKE-STREAM :OUTPUT :ELEMENT-TYPE 'UNSIGNED-BYTE))
           (SETQ *stoutput* *STANDARD-OUTPUT*)
           (SETQ *stinput* *STANDARD-INPUT*)
-          (shen-cl.toplevel-interpret-args (EXT:ARGV)))))
+          (shen-cl.toplevel-interpret-args (COERCE (EXT:ARGV) 'list)))))
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -326,12 +326,12 @@
 (DEFUN shen-cl.repl ()
 
   #+SBCL
-  (HANDLER-CASE (shen.shen)
+  (HANDLER-CASE (shen.repl)
     (SB-SYS:INTERACTIVE-INTERRUPT ()
       (cl.exit 0)))
 
   #-SBCL
-  (shen.shen))
+  (shen.repl))
 
 (DEFUN shen-cl.read-eval (Str)
   (CAR (LAST (MAPC #'eval (read-from-string Str)))))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -348,7 +348,8 @@
         (WITH-OPEN-STREAM (*STANDARD-OUTPUT* (EXT:MAKE-STREAM :OUTPUT :ELEMENT-TYPE 'UNSIGNED-BYTE))
           (SETQ *stoutput* *STANDARD-OUTPUT*)
           (SETQ *stinput* *STANDARD-INPUT*)
-          (shen-cl.toplevel-interpret-args (COERCE (EXT:ARGV) 'LIST)))))
+          (LET ((Args (CONS (CAR (COERCE (EXT:ARGV) 'LIST)) EXT:*ARGS*)))
+            (shen-cl.toplevel-interpret-args Args)))))
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -305,24 +305,6 @@
 (DEFUN number? (N)
   (IF (NUMBERP N) 'true 'false))
 
-(DEFUN shen-cl.print-version ()
-  (FORMAT T "~A~%" *version*)
-  (FORMAT T "Shen-CL ~A~%" *port*)
-  (FORMAT T "~A ~A~%" *implementation* *release*))
-
-(DEFUN shen-cl.print-help ()
-  (FORMAT T "Usage: shen [OPTION]...~%")
-  (FORMAT T "  -e, --eval <EXPR>       : Evaluates EXPR and prints result~%")
-  (FORMAT T "  -h, --help              : Shows this help~%")
-  (FORMAT T "  -l, --load <FILE>       : Reads and evaluates FILE~%")
-  (FORMAT T "  -q, --quiet             : Silences interactive output~%")
-  (FORMAT T "  -r, --repl              : Runs the REPL~%")
-  (FORMAT T "  -s, --set <KEY> <VALUE> : Evaluates KEY, VALUE and sets as global~%")
-  (FORMAT T "  -v, --version           : Prints Shen, shen-cl and ~A version numbers~%" *implementation*)
-  (FORMAT T "~%")
-  (FORMAT T "Evaluates options in left-to-right order~%")
-  (FORMAT T "Starts the REPL by default if no options specified~%"))
-
 (DEFUN shen-cl.repl ()
 
   #+SBCL
@@ -336,49 +318,20 @@
 (DEFUN shen-cl.read-eval (Str)
   (CAR (LAST (MAPC #'eval (read-from-string Str)))))
 
-(DEFUN shen-cl.match-arg? (Arg Options)
-  (MEMBER Arg Options :TEST #'STRING-EQUAL))
-
-(DEFUN shen-cl.interpret-args (Args)
-  (WHEN (CONSP Args)
-    (LET ((Arg (CAR Args)))
-      (COND
-        ((shen-cl.match-arg? Arg (LIST "-e" "--eval"))
-          (print (shen-cl.read-eval (CADR Args)))
-          (shen-cl.interpret-args (CDDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-h" "--help"))
-          (shen-cl.print-version)
-          (FORMAT T "~%")
-          (shen-cl.print-help)
-          (shen-cl.interpret-args (CDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-l" "--load"))
-          (load (CADR Args))
-          (shen-cl.interpret-args (CDDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-q" "--quiet"))
-          (set *hush* 'true)
-          (shen-cl.interpret-args (CDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-r" "--repl"))
-          (shen-cl.repl)
-          (shen-cl.interpret-args (CDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-s" "--set"))
-          (set
-            (shen-cl.read-eval (CADR Args))
-            (shen-cl.read-eval (CADDR Args)))
-          (shen-cl.interpret-args (CDDDR Args)))
-        ((shen-cl.match-arg? Arg (LIST "-v" "--version"))
-          (shen-cl.print-version)
-          (shen-cl.interpret-args (CDR Args)))
-        (T
-          (FORMAT T "~%unrecognized option: ~A~%" Arg)
-          (cl.exit -1))))))
 
 (DEFUN shen-cl.toplevel-interpret-args (Args)
   (trap-error
-    (PROGN
-      (IF (CONSP Args)
-        (shen-cl.interpret-args Args)
-        (shen-cl.repl))
-      (cl.exit 0))
+    (LET ((Result (shen.x.launcher.launch-shen Args)))
+      (COND
+        ((EQ 'error (CAR Result))
+         (PROGN
+          (shen.x.launcher.default-handle-result Result)
+          (cl.exit 1)))
+        ((EQ 'unknown-arguments (CAR Result))
+         (PROGN
+          (shen.x.launcher.default-handle-result Result)
+          (cl.exit 1)))
+        (T (shen.x.launcher.default-handle-result Result))))
     (lambda E
       (PROGN
         (FORMAT T "~%!!! FATAL ERROR: ")
@@ -399,10 +352,10 @@
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))
-      (shen-cl.toplevel-interpret-args (CDR *COMMAND-LINE-ARGUMENT-LIST*)))
+      (shen-cl.toplevel-interpret-args *COMMAND-LINE-ARGUMENT-LIST*))
 
     #+ECL
-    (shen-cl.toplevel-interpret-args (CDR (SI:COMMAND-ARGS)))
+    (shen-cl.toplevel-interpret-args (SI:COMMAND-ARGS))
 
     #+SBCL
-    (shen-cl.toplevel-interpret-args (CDR SB-EXT:*POSIX-ARGV*))))
+    (shen-cl.toplevel-interpret-args SB-EXT:*POSIX-ARGV*)))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -348,7 +348,7 @@
         (WITH-OPEN-STREAM (*STANDARD-OUTPUT* (EXT:MAKE-STREAM :OUTPUT :ELEMENT-TYPE 'UNSIGNED-BYTE))
           (SETQ *stoutput* *STANDARD-OUTPUT*)
           (SETQ *stinput* *STANDARD-INPUT*)
-          (shen-cl.toplevel-interpret-args (EXT.ARGV)))))
+          (shen-cl.toplevel-interpret-args (EXT:ARGV)))))
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -359,7 +359,11 @@
       (shen-cl.toplevel-interpret-args *COMMAND-LINE-ARGUMENT-LIST*))
 
     #+ECL
-    (shen-cl.toplevel-interpret-args (SI:COMMAND-ARGS))
+    (PROGN
+     (shen.initialise)
+     (shen-cl.initialise)
+     (shen.x.features.initialise '(shen/cl shen/cl.ecl))
+     (shen-cl.toplevel-interpret-args (SI:COMMAND-ARGS)))
 
     #+SBCL
     (shen-cl.toplevel-interpret-args SB-EXT:*POSIX-ARGV*)))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -348,7 +348,7 @@
         (WITH-OPEN-STREAM (*STANDARD-OUTPUT* (EXT:MAKE-STREAM :OUTPUT :ELEMENT-TYPE 'UNSIGNED-BYTE))
           (SETQ *stoutput* *STANDARD-OUTPUT*)
           (SETQ *stinput* *STANDARD-INPUT*)
-          (shen-cl.toplevel-interpret-args EXT:*ARGS*))))
+          (shen-cl.toplevel-interpret-args (EXT.ARGV)))))
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -348,7 +348,7 @@
         (WITH-OPEN-STREAM (*STANDARD-OUTPUT* (EXT:MAKE-STREAM :OUTPUT :ELEMENT-TYPE 'UNSIGNED-BYTE))
           (SETQ *stoutput* *STANDARD-OUTPUT*)
           (SETQ *stinput* *STANDARD-INPUT*)
-          (shen-cl.toplevel-interpret-args (COERCE (EXT:ARGV) 'list)))))
+          (shen-cl.toplevel-interpret-args (COERCE (EXT:ARGV) 'LIST)))))
 
     #+CCL
     (HANDLER-BIND ((WARNING #'MUFFLE-WARNING))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -331,7 +331,10 @@
          (PROGN
           (shen.x.launcher.default-handle-result Result)
           (cl.exit 1)))
-        (T (shen.x.launcher.default-handle-result Result))))
+        (T
+         (PROGN
+          (shen.x.launcher.default-handle-result Result)
+          (cl.exit 0)))))
     (lambda E
       (PROGN
         (FORMAT T "~%!!! FATAL ERROR: ")


### PR DESCRIPTION
Did only the minimal for now.

Pending:

- [x] Add "features" extension
- [x] Use "launcher" extension to replace current command line handling
- [x] Reorganize rewrites so that the call to `shen.initialise` is not required before loading it
- [x] Move the call to `shen.initialise` to after the overwrites have been loaded.
- [x] Figure out why ECL broke
- [x] Make sure launcher works fine in implementations other than SBCL

I think that this port can avoid calling `shen.initialise` at startup time if it is called while building the boot image, but I'm not 100% sure.