### PR TITLE
Integrate "factorise-defun" extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   - Reintroduced backend written in Shen.
   - Moved everything in the compiler from the `shen` namespace to `shen-cl`.
   - Command-line handling has been replaced by the "launcher" kernel extension.
+  - `do` expressions now get compiled into `PROGN` expression, making them tail-call optimization friendly.
 
 ### Added
   - Integrated "features" kernel extension.
   - Integrated "launcher" kernel extension.
+  - Integrated "factorise-defun" kernel extension optimization.
   - Source release which includes a pre-compiled `backend.lsp` file.
   - `shen-cl.lisp-true?` to convert from CL to Shen booleans (counterpart to `shen-cl.true?`).
 

--- a/boot.lsp
+++ b/boot.lsp
@@ -201,6 +201,7 @@
 (import-kl "init")
 (import-kl "extension-features")
 (import-kl "extension-launcher")
+(import-kl "extension-factorise-defun")
 (import-lsp "overwrite")
 
 #-ECL

--- a/boot.lsp
+++ b/boot.lsp
@@ -206,10 +206,6 @@
 
 #-ECL
 (PROGN
- ;; required during bootstrap so that
- ;; the `set` in shen-cl.initialise works
- ;; not sure why.
- (SETQ shen-cl.*factorise* 'true)
  (shen.initialise)
  (shen-cl.initialise)
  (shen.x.features.initialise '(

--- a/boot.lsp
+++ b/boot.lsp
@@ -206,6 +206,10 @@
 
 #-ECL
 (PROGN
+ ;; required during bootstrap so that
+ ;; the `set` in shen-cl.initialise works
+ ;; not sure why.
+ (SETQ shen-cl.*factorise* 'true)
  (shen.initialise)
  (shen-cl.initialise)
  (shen.x.features.initialise '(

--- a/src/backend.shen
+++ b/src/backend.shen
@@ -47,6 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
                                                       Label (kl-to-lisp Params LabelBody)]
   _ [defun F Params Code] -> (protect [DEFUN F Params [BLOCK NIL (kl-to-lisp Params Code)]])
   Params [cond | Cond] -> (protect [COND | (lisp.mapcar (/. C (cond_code Params C)) Cond)])
+  Params [do Exp1 Exp2] -> [(protect PROGN) (kl-to-lisp Params Exp1) (kl-to-lisp Params Exp2)]
   _ [lisp. Code | More] -> (if (and (string? Code) (empty? More))
                              (lisp.read-from-string Code)
                              (simple-error "Argument to lisp. must be a literal string"))

--- a/src/backend.shen
+++ b/src/backend.shen
@@ -23,7 +23,9 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
 
-(package shen-cl []
+(package shen-cl [%%let-label %%goto-label %%return]
+
+(set *factorise* false)
 
 (define kl-to-lisp
   Params Param -> Param    where (cons? (lisp.member Param Params))
@@ -34,7 +36,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
   Params [let X Y Z] -> (let ChX (ch-T X)
                           (protect [LET [[ChX (kl-to-lisp Params Y)]]
                                         (kl-to-lisp [ChX | Params] (lisp.subst ChX X Z))]))
-  _ [defun F Params Code] -> (protect [DEFUN F Params (kl-to-lisp Params Code)])
+  _ [defun F Params [cond | Cases]] -> (kl-to-lisp
+                                        []
+                                        (shen.x.factorise-defun.factorise-defun
+                                         [defun F Params [cond | Cases]]))
+      where (value *factorise*)
+  Params [%%return Exp] -> [(protect RETURN) (kl-to-lisp Params Exp)]
+  Params [%%goto-label Label | _] -> [(protect GO) Label]
+  Params [%%let-label [Label | _] LabelBody Body] -> [(protect TAGBODY) (kl-to-lisp Params Body)
+                                                      Label (kl-to-lisp Params LabelBody)]
+  _ [defun F Params Code] -> (protect [DEFUN F Params [BLOCK NIL (kl-to-lisp Params Code)]])
   Params [cond | Cond] -> (protect [COND | (lisp.mapcar (/. C (cond_code Params C)) Cond)])
   _ [lisp. Code | More] -> (if (and (string? Code) (empty? More))
                              (lisp.read-from-string Code)

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -133,6 +133,8 @@
 
 (DEFUN shen-cl.initialise ()
   (PROGN
+    (set shen-cl.*factorise* 'true)
+
     (put      'cl.exit 'arity 1 *property-vector*)
     (put 'shen-cl.exit 'arity 1 *property-vector*)
 

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -133,7 +133,7 @@
 
 (DEFUN shen-cl.initialise ()
   (PROGN
-    (set shen-cl.*factorise* 'true)
+    (set 'shen-cl.*factorise* 'true)
 
     (put      'cl.exit 'arity 1 *property-vector*)
     (put 'shen-cl.exit 'arity 1 *property-vector*)


### PR DESCRIPTION
It is enabled for user code, but the kernel itself is not compiled with this optimization enabled.

It is complicated because the kernel has to compile itself, and the extension relies on having Shen loaded for some stuff. Since the boot process compiles itself as it goes there is a chicken/egg problem here.

Switching to Shen/Scheme's model, where a full external Shen is used to build it could solve this problem, but maybe better left for later (if Shen/Scheme's compiler gets ported here, then the solution comes with it).

Running the Shen test suite takes the same amount of time with factorisation enabled or disabled (basically same as in Shen/Scheme, what is important is that it is not slower).

Times for the same functions I used to test this in Shen/Scheme:

```
simplify regular 
Evaluation took:
  3.864 seconds of real time
  3.845448 seconds of total run time (3.791698 user, 0.053750 system)
  [ Run times consist of 0.024 seconds GC time, and 3.822 seconds non-GC time. ]
  99.51% CPU
  9,272,407,653 processor cycles
  2,240,019,872 bytes consed
  
simplify optimized 
Evaluation took:
  3.431 seconds of real time
  3.415437 seconds of total run time (3.393865 user, 0.021572 system)
  [ Run times consist of 0.023 seconds GC time, and 3.393 seconds non-GC time. ]
  99.53% CPU
  8,231,804,550 processor cycles
  2,240,001,680 bytes consed
  
neal regular 
Evaluation took:
  4.307 seconds of real time
  4.290840 seconds of total run time (4.276924 user, 0.013916 system)
  [ Run times consist of 0.002 seconds GC time, and 4.289 seconds non-GC time. ]
  99.63% CPU
  10,336,071,522 processor cycles
  320,012,288 bytes consed
  
neal optimized 
Evaluation took:
  3.137 seconds of real time
  3.125138 seconds of total run time (3.115084 user, 0.010054 system)
  [ Run times consist of 0.002 seconds GC time, and 3.124 seconds non-GC time. ]
  99.62% CPU
  7,527,416,121 processor cycles
  320,006,912 bytes consed
```