### PR TITLE
Native overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+  - `@p` and `vector` constructors are now overriden by better performing native implementations.
+  - `read-file-as-bytelist`, `shen.read-file-as-charlist` and `shen.read-file-as-charlist` are also overriden by native implementations.
+
 ### [3.0.0] - 2019-10-12
 
 **Updated to Shen Open Source Kernel 22.2**

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -187,6 +187,35 @@
     (force-output s))
   x)
 
+;; file reading
+
+(defun |read-file-as-bytelist| (path)
+  (with-open-file (stream (format nil "~A~A" |*home-directory*| path) :direction :input :element-type 'unsigned-byte)
+    (let ((data (make-array (file-length stream) :element-type 'unsigned-byte :initial-element 0)))
+      (read-sequence data stream)
+      (coerce data 'list))))
+
+(defun |shen.read-file-as-charlist| (path)
+  (|read-file-as-bytelist| path))
+
+(defun |shen.read-file-as-string| (path)
+  (with-open-file (stream (format nil "~A~A" |*home-directory*| path) :direction :input)
+    (let ((data (make-string (file-length stream))))
+      (read-sequence data stream)
+      data)))
+
+;; tuples
+
+(defun |@p| (x y)
+  (vector '|shen.tuple| x y))
+
+;; vectors
+
+(defun |vector| (n)
+  (let ((vec (make-array (1+ n) :initial-element (|fail|))))
+    (setf (svref vec 0) n)
+    vec))
+
 ; Amend the REPL credits message to explain exit command
 (setf (symbol-function '|shen-cl.original-credits|) #'|shen.credits|)
 

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -132,13 +132,16 @@
   `(function (lambda () ,x)))
 
 (defun |absvector| (n)
-  (make-array (list n)))
+  (make-array n))
 
 (defun |absvector?| (x)
-  (if (and (arrayp x) (not (stringp x))) '|true| '|false|))
+  (if (and (arrayp x) (not (stringp x)))
+     '|true|
+     '|false|))
 
 (defun |address->| (vector n value)
-  (setf (svref vector n) value) vector)
+  (setf (svref vector n) value)
+  vector)
 
 (defun |<-address| (vector n)
   (svref vector n))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -93,19 +93,19 @@
       (error "~S is not an exception~%" e)))
 
 (defun |cons| (X Y)
-  (CONS X Y))
+  (cons X Y))
 
 (defun |hd| (X)
-  (CAR X))
+  (car X))
 
 (defun |tl| (X)
-  (CDR X))
+  (cdr X))
 
 (defun |cons?| (X)
-  (if (CONSP X) '|true| '|false|))
+  (if (consp X) '|true| '|false|))
 
 (defun |intern| (String)
-  (INTERN (|shen-cl.process-intern| String)))
+  (intern (|shen-cl.process-intern| String)))
 
 (defun |shen-cl.process-intern| (S)
   (cond


### PR DESCRIPTION
Some overrides that worked well in Shen/Scheme

File reading overrides read the file into a pre-allocated buffer in one pass instead of byte by byte.

The tuple and vector constructors are overriden based on https://github.com/tizoc/shen-scheme/issues/9

Results for those same tests (but the amount of runs cut in 10):

| name | overrides | no overrides | 2.7.0 | 2.5.0 |
| ----- | -------------- | ----------------- | ------- | --------- |
| vec-read | 1.0780 | 1.0800 | 1.0449 | 1.2870 |
| vec-read+build@v | 5.1330 | 12.0230 | 6.5480 | 7.7049 |
| vec-read+build | 2.8600 | 6.7909 | 3.9850 | 4.5209 |
| list-hd | 0.7720 | 0.8120 | 0.7730 | 1.1529 |
| list-hd+cons | 1.0220 | 1.0720 | 1.0260 | 1.2529 |
| tuple-fst+build | 1.9019 | 5.4489 | 3.3200 | 3.1049 |
| control | 0.7730 | 0.7729 | 0.7720 | 0.9850 |
| total | 13.5720 | 28.0379 | 17.5180 | 20.0480 |

For some reason, v3.0.0 without overrides is slower than both 2.7.0 and 2.5.0 in some cases, which means that in the transition to the new compiler I made some things worse, I have to investigate that. But overall, overriding those constructors improves performance like it did in Shen/Scheme.
 
code:

```shen
(package null []
 (define r
   V 100000000 -> ok
   V N -> (r V (+ N (<-address V 1))))

 (define rb1
   V 100000000 -> ok
   V N -> (rb1 (@v 1 <>)
               (+ N (<-address V 1))))

 (define rb2
   V 100000000 -> ok
   V N -> (rb2 (address-> (vector 1) 1 1)
               (+ N (<-address V 1))))

 (define c
   C 100000000 -> ok
   C N -> (c C (+ N (hd C))))

 (define c/b
   C 100000000 -> ok
   C N -> (c/b [1] (+ N (hd C))))

 (define t/b
   C 100000000 -> ok
   C N -> (t/b (@p 1 []) (+ N (fst C))))

 (define control
   C 100000000 -> ok
   C N -> (control C (+ N 1))))

(define collect-garbage
  -> (lisp. "(SB-EXT:GC)"))

(do (collect-garbage) (time (r (@v 1 <>) 1)))
(do (collect-garbage) (time (rb1 (@v 1 <>) 1)))
(do (collect-garbage) (time (rb2 (@v 1 <>) 1)))
(do (collect-garbage) (time (c  [1] 1)))
(do (collect-garbage) (time (c/b  [1] 1)))
(do (collect-garbage) (time (t/b (@p 1 []) 1)))
(do (collect-garbage) (time (control unit 1)))
```