### PR TITLE
Overrides for `symbol?` and `variable?` predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+  - Overrides for `symbol?` and `variable?`. This speeds up the time it takes for `eval` to compile expressions considerably.
+
 ### [3.0.1] - 2019-10-13
 
 ### Changed

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -66,7 +66,8 @@
            (not (eq t val))
            (not (eq val '|true|))
            (not (eq val '|false|))
-           (upper-case-p (char (symbol-name val) 0)))
+           (upper-case-p (char (symbol-name val) 0))
+           (every #'symbol-characterp (symbol-name val)))
       '|true|
       '|false|))
 

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -268,7 +268,7 @@
   (|shen-cl.lisp-true?|
     (and (not (null symbol))
          (symbolp symbol)
-         (|shen-cl.prefix?| (|str| symbol) "lisp."))))
+         (|shen-cl.prefix?| (symbol-name symbol) "lisp."))))
 
 (defun |shen-cl.remove-lisp-prefix| (symbol)
   (|intern| (subseq (symbol-name symbol) 5)))

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -28,9 +28,11 @@
 (defvar |shen-cl.kernel-sysfunc?| (fdefinition '|shen.sysfunc?|))
 
 (defun |shen.sysfunc?| (symbol)
-  (or
-    (apply |shen-cl.kernel-sysfunc?| (list symbol))
-    (|shen-cl.lisp-prefixed?| symbol)))
+  (if (not (symbolp symbol))
+      '|false|
+      (|or|
+        (|shen-cl.lisp-prefixed?| symbol)
+        (apply |shen-cl.kernel-sysfunc?| (list symbol)))))
 
 (defun shen.pvar? (x)
   (if (and (arrayp x) (not (stringp x)) (eq (svref x 0) '|shen.pvar|))

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -34,8 +34,41 @@
 
 (defun shen.pvar? (x)
   (if (and (arrayp x) (not (stringp x)) (eq (svref x 0) '|shen.pvar|))
-    '|true|
-    '|false|))
+      '|true|
+      '|false|))
+
+(defvar specials (coerce "=*/+-_?$!@~><&%{}:;`#'." 'list))
+
+(defun symbol-characterp (c)
+  (or (alphanumericp c)
+      (not (null (member c specials)))))
+
+(defun |shen.analyse-symbol?| (s)
+  (if (and (> (length s) 0)
+           (not (digit-char-p (char s 0)))
+           (symbol-characterp (char s 0))
+           (every #'symbol-characterp s))
+      '|true|
+      '|false|))
+
+(defun |symbol?| (val)
+  (if (and (symbolp val)
+           (not (null val))
+           (not (eq t val))
+           (not (eq val '|true|))
+           (not (eq val '|false|)))
+      (|shen.analyse-symbol?| (|str| val))
+      '|false|))
+
+(defun |variable?| (val)
+  (if (and (symbolp val)
+           (not (null val))
+           (not (eq t val))
+           (not (eq val '|true|))
+           (not (eq val '|false|))
+           (upper-case-p (char (symbol-name val) 0)))
+      '|true|
+      '|false|))
 
 (defun |shen.lazyderef| (x process-n)
   (if (and (arrayp x) (not (stringp x)) (eq (svref x 0) '|shen.pvar|))

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -298,12 +298,6 @@
          (lispname (string-upcase (substitute #\: #\. (subseq str 5)))))
     (intern lispname)))
 
-(defun |shen-cl.lisp-prefixed?| (symbol)
-  (|shen-cl.lisp-true?|
-    (and (not (null symbol))
-         (symbolp symbol)
-         (|shen-cl.prefix?| (str symbol) "lisp."))))
-
 (defun |shen-cl.process-string| (x)
   (cond
     ((string-equal x "")                    x)


### PR DESCRIPTION
The compiler uses these predicates a lot and the Shen implementations are quite sub-optimal, overriding these helps.

On my computer running the tests takes 3.32s without these overrides and 2.76s with them.
