### PR TITLE
Add ABCL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
     install:
       - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
       - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
-      - sudo cp *.jar /usr/local/bin/
-      - sudo printf '#!/bin/bash\njava -jar ./abcl.jar $@' > /usr/local/bin/abcl
-      - sudo chmod a+x /usr/local/bin/acbl
+      - printf '#!/bin/bash\njava -jar ./abcl.jar $@' > abcl
+      - chmod a+x acbl
+      - PATH=$PATH:$(pwd)
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb
       - wget http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 notifications:
   email: false
-language: generic
+language: java
 sudo: required
 env:
   global:
@@ -14,6 +14,9 @@ matrix:
       - MAKE_BUILD_TARGET=all
       - SHEN=./shen
     install:
+      - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
+      - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
+      - alias abcl='java -jar abcl.jar'
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb
       - wget http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     install:
       - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
       - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
+      - cp *.jar /usr/local/bin/
+      - printf '#!/bin/bash\njava -jar ./abcl.jar $@' > /usr/local/bin/abcl
+      - chmod a+x /usr/local/bin/acbl
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb
       - wget http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb
@@ -63,7 +66,6 @@ addons:
       - ecl
       - libffi-dev
 script:
-  - alias abcl="java -jar abcl.jar"
   - make fetch
   - make precompile
   - make $MAKE_BUILD_TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
     install:
       - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
       - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
-      - alias abcl='java -jar abcl.jar'
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb
       - wget http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb
@@ -64,6 +63,7 @@ addons:
       - ecl
       - libffi-dev
 script:
+  - alias abcl="java -jar abcl.jar"
   - make fetch
   - make precompile
   - make $MAKE_BUILD_TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
     install:
       - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
       - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
-      - cp *.jar /usr/local/bin/
-      - printf '#!/bin/bash\njava -jar ./abcl.jar $@' > /usr/local/bin/abcl
-      - chmod a+x /usr/local/bin/acbl
+      - sudo cp *.jar /usr/local/bin/
+      - sudo printf '#!/bin/bash\njava -jar ./abcl.jar $@' > /usr/local/bin/abcl
+      - sudo chmod a+x /usr/local/bin/acbl
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb
       - wget http://http.us.debian.org/debian/pool/main/s/sbcl/sbcl_1.3.14-2+b1_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       - wget https://abcl.org/releases/1.8.0/abcl-bin-1.8.0.tar.gz
       - tar xzf abcl-bin-1.8.0.tar.gz --strip-components=1 --wildcards *.jar
       - printf '#!/bin/bash\njava -jar ./abcl.jar $@' > abcl
-      - chmod a+x acbl
+      - chmod a+x abcl
       - PATH=$PATH:$(pwd)
       - wget http://mr.gy/blog/clozure-cl_1.11_amd64.deb
       - sudo dpkg -i clozure-cl_1.11_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ ifeq ($(OSName),windows)
 	Slash=\\\\
 	ArchiveSuffix=.zip
 	BinarySuffix=.exe
-	All=clisp ccl sbcl
+	All=abcl clisp ccl sbcl
 	PS=powershell.exe -Command
 else
 	Slash=/
 	ArchiveSuffix=.tar.gz
 	BinarySuffix=
-	All=clisp ccl ecl sbcl
+	All=abcl clisp ccl ecl sbcl
 	ifeq ($(OSName),freebsd)
 		All=ccl ecl sbcl
 	else ifeq ($(OSName),openbsd)
@@ -52,6 +52,7 @@ else
 	endif
 endif
 
+ABCL=abcl
 CCL=ccl
 CLISP=clisp
 ECL=ecl
@@ -74,6 +75,7 @@ KernelArchiveName=$(KernelFolderName)$(ArchiveSuffix)
 KernelArchiveUrl=$(UrlRoot)/$(KernelTag)/$(KernelArchiveName)
 BinaryName=shen$(BinarySuffix)
 
+ShenABCL=.$(Slash)bin$(Slash)abcl$(Slash)$(BinaryName)
 ShenCLisp=.$(Slash)bin$(Slash)clisp$(Slash)$(BinaryName)
 ShenCCL=.$(Slash)bin$(Slash)ccl$(Slash)$(BinaryName)
 ShenECL=.$(Slash)bin$(Slash)ecl$(Slash)$(BinaryName)
@@ -96,6 +98,9 @@ SourceReleaseName=shen-cl-$(GitVersion)-sources
 .DEFAULT: all
 .PHONY: all
 all: $(All)
+
+.PHONY: abcl
+abcl: build-abcl test-abcl
 
 .PHONY: clisp
 clisp: build-clisp test-clisp
@@ -151,6 +156,10 @@ endif
 # Build an implementation
 #
 
+.PHONY: build-abcl
+build-abcl:
+	$(ABCL) --load boot.lsp
+
 .PHONY: build-clisp
 build-clisp:
 	$(CLISP) -i boot.lsp
@@ -171,6 +180,10 @@ build-sbcl:
 # Test an implementation
 #
 
+.PHONY: test-abcl
+test-abcl:
+	$(RunABCL) $(Tests)
+
 .PHONY: test-clisp
 test-clisp:
 	$(RunCLisp) $(Tests)
@@ -190,6 +203,10 @@ test-sbcl:
 #
 # Run an implementation
 #
+
+.PHONY: run-abcl
+run-abcl:
+	$(RunABCL) $(Args)
 
 .PHONY: run-clisp
 run-clisp:

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,13 @@ KernelArchiveName=$(KernelFolderName)$(ArchiveSuffix)
 KernelArchiveUrl=$(UrlRoot)/$(KernelTag)/$(KernelArchiveName)
 BinaryName=shen$(BinarySuffix)
 
-ShenABCL=.$(Slash)bin$(Slash)abcl$(Slash)$(BinaryName)
+ShenABCL=.$(Slash)bin$(Slash)abcl$(Slash)shen.jar
 ShenCLisp=.$(Slash)bin$(Slash)clisp$(Slash)$(BinaryName)
 ShenCCL=.$(Slash)bin$(Slash)ccl$(Slash)$(BinaryName)
 ShenECL=.$(Slash)bin$(Slash)ecl$(Slash)$(BinaryName)
 ShenSBCL=.$(Slash)bin$(Slash)sbcl$(Slash)$(BinaryName)
 
+RunABCL=java -jar $(ShenABCL) --
 RunCLisp=$(ShenCLisp) --clisp-m 10MB
 RunCCL=$(ShenCCL)
 RunECL=$(ShenECL)
@@ -159,6 +160,9 @@ endif
 .PHONY: build-abcl
 build-abcl:
 	$(ABCL) --load boot.lsp
+	javac -cp abcl.jar -d bin/abcl src/ShenABCL.java
+	cp src/ShenABCLManifest.txt bin/abcl
+	cd bin/abcl; jar cfm shen.jar ShenABCLManifest.txt ShenABCL.class shen.abcl
 
 .PHONY: build-clisp
 build-clisp:

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,16 @@ endif
 .PHONY: build-abcl
 build-abcl:
 	$(ABCL) --load boot.lsp
-	javac -cp abcl.jar -d bin/abcl src/ShenABCL.java
-	cp src/ShenABCLManifest.txt bin/abcl
-	cd bin/abcl; jar cfm shen.jar ShenABCLManifest.txt ShenABCL.class shen.abcl
+# NOTE: this depends on CLASSPATH being set
+#       java is not finding classes from abcl.jar
+#       refer to https://abcl-dev.blogspot.com/2009/09/loading-fasls-from-jar-files.html
+
+#       can run with abcl... (load "bin/abcl/shen.abcl")... (IN-PACKAGE :SHEN)... (|shen-cl.toplevel|)
+#       but gets FATAL ERROR and exits
+
+#	javac -d bin/abcl src/ShenABCL.java
+#	cp src/ShenABCLManifest.txt bin/abcl
+#	cd bin/abcl; jar cfm shen.jar ShenABCLManifest.txt ShenABCL.class shen.abcl
 
 .PHONY: build-clisp
 build-clisp:
@@ -186,7 +193,9 @@ build-sbcl:
 
 .PHONY: test-abcl
 test-abcl:
-	$(RunABCL) $(Tests)
+# NOTE: test-abcl disabled since build is not working
+#	$(RunABCL) $(Tests)
+	echo 'test-abcl disabled'
 
 .PHONY: test-clisp
 test-clisp:
@@ -210,7 +219,9 @@ test-sbcl:
 
 .PHONY: run-abcl
 run-abcl:
-	$(RunABCL) $(Args)
+# NOTE: run-abcl disabled since build is not working
+#	$(RunABCL) $(Args)
+	echo 'run-abcl disabled'
 
 .PHONY: run-clisp
 run-clisp:

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,3 +1,5 @@
+# TODO: cover ABCL in this doc
+
 # Prerequisites
 
   * For [BSD](#bsd)
@@ -36,7 +38,7 @@ If the version of SBCL available throught `apt` is too old, a sufficiently new v
 
 ## macOS
 
-CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install clisp clozure-cl ecl sbcl`.
+ABCL, CLisp, Clozure, ECL and SBCL can be acquired through Homebrew with `brew install abcl clisp clozure-cl ecl sbcl`.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 This codebase currently supports the following implementations:
 
+  * [Armed Bear Common Lisp](https://abcl.org/)
   * [GNU CLisp](http://www.clisp.org/)
   * [Clozure Common Lisp](http://ccl.clozure.com/)
   * [Embeddable Common Lisp](https://common-lisp.net/project/ecl/)
@@ -52,7 +53,7 @@ The `Makefile` automates all build and test operations.
 | `run-X`      | Start Shen REPL.                             |
 | `release`    | Creates archive of compiled binaries.        |
 
-`X` can be `clisp`, `ccl`, `ecl`, `sbcl` or it can be `all`, which will run the command for all of the preceding.
+`X` can be `abcl`, `clisp`, `ccl`, `ecl`, `sbcl` or it can be `all`, which will run the command for all of the preceding.
 
 `precompile` is only required when bootstraping Shen/CL from this repository, the source release includes the precompiled files. The `SHEN` variable has to be defined and point to a working Shen executable that will be used to precompile the kernel and compiler code.
 

--- a/boot.lsp
+++ b/boot.lsp
@@ -48,8 +48,10 @@
 
 #+abcl
 (progn
+  (defvar *compiled-files* nil)
   (defconstant compiled-suffix ".abcl")
   (defconstant binary-path "./bin/abcl/")
+  (defconstant concatenated-fasl-path (format nil "~Ashen~A" binary-path compiled-suffix))
   (defconstant executable-name #+windows "shen.exe" #-windows "shen"))
 
 #+clisp
@@ -91,8 +93,10 @@
 
 #-ecl
 (defun compile-lsp (file)
-  (let ((lsp-file (format nil "~A~A.lsp" binary-path file)))
-    (compile-file lsp-file)))
+  (let ((lsp-file (format nil "~A~A.lsp" binary-path file))
+        (fas-file (format nil "~A~A~A" binary-path file compiled-suffix)))
+    (compile-file lsp-file)
+    #+abcl (push fas-file *compiled-files*)))
 
 #+ecl
 (defun compile-lsp (file)
@@ -188,8 +192,7 @@
 
 #+abcl
 (progn
-  (format nil "~%~%TODO: how to emit executable for ABCL???~%~%")
-  (|shen-cl.toplevel|)
+  (system:concatenate-fasls (reverse *compiled-files*) concatenated-fasl-path)
   (ext:quit))
 
 #+clisp

--- a/boot.lsp
+++ b/boot.lsp
@@ -46,6 +46,12 @@
 ; Implementation-Specific Declarations
 ;
 
+#+abcl
+(progn
+  (defconstant compiled-suffix ".abcl")
+  (defconstant binary-path "./bin/abcl/")
+  (defconstant executable-name #+windows "shen.exe" #-windows "shen"))
+
 #+clisp
 (progn
   (defconstant compiled-suffix ".fas")
@@ -56,7 +62,7 @@
 
 #+ccl
 (progn
-  (defconstant compiled-suffix (format nil "~a" *.fasl-pathname*))
+  (defconstant compiled-suffix (format nil "~A" *.fasl-pathname*))
   (defconstant binary-path "./bin/ccl/")
   (defconstant executable-name #+windows "shen.exe" #-windows "shen"))
 
@@ -164,9 +170,10 @@
  (|shen-cl.initialise|)
  (|shen.x.features.initialise| '(
    |shen/cl|
+   #+abcl  |shen/cl.abcl|
    #+clisp |shen/cl.clisp|
-   #+sbcl  |shen/cl.sbcl|
    #+ccl   |shen/cl.ccl|
+   #+sbcl  |shen/cl.sbcl|
  )))
 
 (fmakunbound 'compile-lsp)
@@ -178,6 +185,12 @@
 ;
 
 (defconstant executable-path (format nil "~A~A" binary-path executable-name))
+
+#+abcl
+(progn
+  (format nil "~%~%TODO: how to emit executable for ABCL???~%~%")
+  (|shen-cl.toplevel|)
+  (ext:quit))
 
 #+clisp
 (progn

--- a/src/ShenABCL.java
+++ b/src/ShenABCL.java
@@ -1,0 +1,27 @@
+// Based on code by Didier Verna found at
+// https://www.didierverna.net/blog/index.php?post/2011/01/22/Towards-ABCL-Standalone-Executables
+
+import java.util.stream.Stream;
+import org.armedbear.lisp.*;
+
+public class ShenABCL {
+    public static void main(String[] args) {
+        Runnable runShen = () -> {
+            try {
+                LispObject cmdline = Stream.of(args)
+                    .reduce(Lisp.NIL.getSymbolValue(), (x, y) -> new Cons(y, x), (z, w) -> z)
+                    .nreverse();
+                Lisp._COMMAND_LINE_ARGUMENT_LIST_.setSymbolValue(cmdline);
+                Interpreter.createInstance();
+                Load.load(ShenABCL.class.getResourceAsStream("shen.abcl"));
+            } catch (ProcessingTerminated e) {
+                System.exit(e.getStatus());
+            } catch (Exception e) {
+                System.err.println("Uncaught Exception:");
+                e.printStackTrace();
+                System.exit(1);
+            }
+        };
+        new Thread(null, runShen, "shen-abcl", 4194304L).start();
+    }
+}

--- a/src/ShenABCLManifest.txt
+++ b/src/ShenABCLManifest.txt
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Sealed: true
+Class-Path: abcl.jar abcl-contrib.jar
+Main-Class: ShenABCL

--- a/src/ShenABCLManifest.txt
+++ b/src/ShenABCLManifest.txt
@@ -1,4 +1,3 @@
 Manifest-Version: 1.0
 Sealed: true
-Class-Path: abcl.jar abcl-contrib.jar
 Main-Class: ShenABCL

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -175,6 +175,10 @@
                  (setf acc (funcall (funcall (funcall f k) v) acc))) dict)
     acc))
 
+#+abcl
+(defun |cl.exit| (code)
+  (ext:quit :status code))
+
 #+clisp
 (defun |cl.exit| (code)
   (ext:exit code))

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -258,8 +258,10 @@
     vec))
 
 ; Amend the REPL credits message to explain exit command
+#-abcl
 (setf (symbol-function '|shen-cl.original-credits|) #'|shen.credits|)
 
+#-abcl
 (defun |shen.credits| ()
   (|shen-cl.original-credits|)
   (format t "exit REPL with (cl.exit)"))

--- a/src/package.lsp
+++ b/src/package.lsp
@@ -25,7 +25,7 @@
 
 (defpackage :shen
   (:documentation "This is the package in which the Shen language operates.")
-  #+clisp
+  #+(or abcl clisp)
   (:use :common-lisp
         :ext)
   #+ccl

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -210,9 +210,20 @@
     (t
      nil)))
 
+#+abcl
+(defun |write-byte| (byte s)
+  (write-byte (code-char s) s))
+
+#+abcl
+(defun |read-byte| (s)
+  (let ((ch (read-char s nil -1)))
+    (if (eq -1 ch) ch (char-code ch))))
+
+#-abcl
 (defun |write-byte| (byte s)
   (write-byte byte s))
 
+#-abcl
 (defun |read-byte| (s)
   (read-byte s nil -1))
 

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -32,6 +32,12 @@
 (defvar |*port*| "3.0.3")
 (defvar |*porters*| "Mark Tarver, Robert Koeninger and Bruno Deferrari")
 
+#+abcl
+(progn
+  (defvar |*implementation*| "ABCL")
+  (defvar |*release*| (lisp-implementation-version))
+  (defvar |*os*| (or #+windows "Windows" #+linux "Linux" #+darwin "macOS" #+unix "Unix" "Unknown")))
+
 #+clisp
 (progn
   (defvar |*implementation*| "GNU CLisp")
@@ -362,7 +368,6 @@
 (defun |shen-cl.read-eval| (str)
   (car (last (mapc #'|eval| (|read-from-string| str)))))
 
-
 (defun |shen-cl.toplevel-interpret-args| (args)
   (|trap-error|
     (let ((result (|shen.x.launcher.launch-shen| args)))
@@ -398,7 +403,7 @@
           (let ((args (cons (car (coerce (ext:argv) 'list)) ext:*args*)))
             (|shen-cl.toplevel-interpret-args| args)))))
 
-    #+ccl
+    #+(or abcl ccl)
     (handler-bind ((warning #'muffle-warning))
       (|shen-cl.toplevel-interpret-args| *command-line-argument-list*))
 


### PR DESCRIPTION
Fixes #51 

### Discussion

Working on this raised a question about how this would be distributed for Armed Bear. ABCL runs on Java so it would distributed as a `.jar` file?

This also reminds me about source distribution (rendering a `shen.lisp` with the source in this repo including the translated kernel) that would be multi-lingual. Looking in the [asdf.lisp](https://gitlab.common-lisp.net/abcl/abcl/-/blob/master/src/org/armedbear/lisp/asdf.lisp#L4835) file including in some CL projects, it might be able to handle multi-platform related stuff for us.

### Testing Notes

Running `make build-abcl` might work depending on if you have abcl.jar in the repo checkout root (and java installed) (and it might have to be java 8). `build-abcl` compiles the .lsp files for abcl, compiles a .java file that has the main method used for entrypoint (to collect args and start shen.abcl) and puts it in a `bin/abcl/shen.jar` file.

Running `make run-abcl` will try to run `java -jar bin/abcl/shen.jar` which isn't working for me right now. I get a `ClassDefNotFoundError` for the abcl stuff. Probably can't find abcl. Don't know why.

CC: @tizoc @junkerjoe