### PR TITLE
Backport improvements from the official S41.1 distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - GitHub Actions release workflow that builds and publishes prebuilt SBCL binaries for Linux (`x86_64`, `aarch64`) and macOS (`arm64`, plus a best-effort `x86_64`) on tagged releases.
+- `thread` and `terminate` threading natives on SBCL (ported from the official S41.1 distribution), registered via `update-lambda-table`. The kernel's concurrency library (`kernel/lib/concurrency`) now loads and runs.
 
 ### Changed
 
 - Build pipeline updated for kernel 41.1: integrated the `stlib` and `extension-expand-dynamic` kernel extensions, and dropped the `factorise-defun` extension (its optimization is now implemented natively).
 - Test target now loads the kernel's `runme.shen` harness.
+- `absvector` now initializes elements to the `(fail)` sentinel, matching the official S41.1 port and Shen/Scheme, so `<-vector` on an unset slot of a raw absvector signals "not found" instead of returning an implementation-defined value.
+- `pos`, `tlstr`, `n->string` and `string->n` validate their arguments and signal the same descriptive errors as the official S41.1 port (e.g. `"ab" is not a unit string`) instead of leaking raw Common Lisp conditions.
 
 ### Fixed
 
@@ -32,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - O(N) native overrides for the reader primitives `shen.str->bytes`, `shen.bytes->string`, `shen.rfas-h` and `shen.reader-error-message`, replacing O(N²) recursive concatenation.
 - `macroexpand` now extracts the macro functions once and uses an `EQ` fast-path to skip deep-equality checks when a macro leaves its input unchanged.
 - Native KL `cond` factorization that groups consecutive clauses sharing a leading `and` test, reducing redundant guard evaluation.
+- `(length X)` now compiles to Common Lisp's optimized `LIST-LENGTH` instead of the kernel's recursive `length` (ported from the official S41.1 backend).
 
 ## [3.0.3] - 2019-12-07
 

--- a/src/compiler.shen
+++ b/src/compiler.shen
@@ -1,7 +1,7 @@
 \\ Copyright (c) 2012-2019 Bruno Deferrari.  All rights reserved.
 \\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
 
-(package shen-cl [progn quote null car cdr t nil
+(package shen-cl [progn quote null car cdr list-length t nil
                   numberp stringp consp funcall
                   list eq eql equal equalp let*
                   lisp.defun lisp.lambda lisp.block lisp.
@@ -299,6 +299,7 @@ but not otherwise.
 (define unary-op-mapping
   hd              -> (cl car)
   tl              -> (cl cdr)
+  length          -> (cl list-length)
   _               -> (fail))
 
 (define optimise-static-application

--- a/src/native.lsp
+++ b/src/native.lsp
@@ -43,3 +43,17 @@
   (|shen-cl.with-temp-readcase| readtable-case
     (let ((*package* (find-package package)))
      (eval (read-from-string string)))))
+
+;; Threading natives required by the kernel's concurrency library
+;; (kernel/lib/concurrency): (thread Lazy) starts a frozen computation on a
+;; new thread, (terminate Thread) kills it. Both are declared
+;; thread-returning in concurrency.dtype, so terminate returns its argument
+;; even when the thread has already finished.
+#+sbcl
+(progn
+  (defun |thread| (lazy)
+    (sb-thread:make-thread lazy))
+
+  (defun |terminate| (thread)
+    (handler-case (progn (sb-thread:terminate-thread thread) thread)
+      (error () thread))))

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -265,7 +265,13 @@
     (|declare| '|shen-cl.exit| (list '|number| '--> '|unit|))
 
     (|shen-cl.read-eval| "(defmacro      cl.exit-macro      [cl.exit] -> [cl.exit 0])")
-    (|shen-cl.read-eval| "(defmacro shen-cl.exit-macro [shen-cl.exit] -> [cl.exit 0])")))
+    (|shen-cl.read-eval| "(defmacro shen-cl.exit-macro [shen-cl.exit] -> [cl.exit 0])")
+
+    ;; Register the threading natives (defined in native.lsp) so they have
+    ;; a known arity and can be passed around as first-class functions;
+    ;; mirrors (update-lambda-table 'thread 1) in the official S41.1 build.
+    #+sbcl (|update-lambda-table| '|thread| 1)
+    #+sbcl (|update-lambda-table| '|terminate| 1)))
 
 #+(or ccl sbcl)
 (defun |shen.read-char-code| (s)

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -137,8 +137,12 @@
 (defmacro |freeze| (x)
   `(function (lambda () ,x)))
 
+;; Elements start as the fail sentinel so that reading an unset slot via
+;; <-vector signals "not found", matching the official S41.1 port and
+;; Shen/Scheme. (|fail|) is kernel-defined and only called at runtime,
+;; after the kernel has loaded.
 (defun |absvector| (n)
-  (make-array n))
+  (make-array n :initial-element (|fail|)))
 
 (defun |absvector?| (x)
   (if (and (arrayp x) (not (stringp x)))
@@ -247,10 +251,17 @@
   nil)
 
 (defun |pos| (x n)
-  (coerce (list (char x n)) 'string))
+  (cond
+    ((not (stringp x))
+     (error "~A is not a string~%" x))
+    ((or (not (integerp n)) (minusp n) (>= n (length x)))
+     (error "~A is not a natural number less than the length of the string~%" n))
+    (t (string (char x n)))))
 
 (defun |tlstr| (x)
-  (subseq x 1))
+  (if (and (stringp x) (plusp (length x)))
+      (subseq x 1)
+      (error "~S is not a non-empty string~%" x)))
 
 (defun |cn| (str1 str2)
   (declare (type string str1) (type string str2))
@@ -260,10 +271,15 @@
   (if (stringp s) '|true| '|false|))
 
 (defun |n->string| (n)
-  (format nil "~C" (code-char n)))
+  (let ((c (and (integerp n) (not (minusp n)) (< n char-code-limit) (code-char n))))
+    (if c
+        (string c)
+        (error "~A is not a natural number~%" n))))
 
 (defun |string->n| (s)
-  (char-code (car (coerce s 'list))))
+  (if (and (stringp s) (= 1 (length s)))
+      (char-code (char s 0))
+      (error "~S is not a unit string~%" s)))
 
 (defun |str| (x)
   (cond

--- a/tests/compiler-tests.shen
+++ b/tests/compiler-tests.shen
@@ -202,6 +202,12 @@
  (shen-cl.kl->lisp [cons 1 [cons 2 []]])
  [(shen-cl.cl list) 1 2])
 
+\\ (length X) compiles to CL's optimised LIST-LENGTH instead of the
+\\ kernel's recursive length (ported from the official S41.1 backend).
+(assert-equal
+ (shen-cl.compile-expression [length X] [X])
+ [(shen-cl.cl list-length) X])
+
 (set shen-cl.*compiling-shen-sources* true)
 
 (assert-equal


### PR DESCRIPTION
**Stacked on #60** (which stacks on #58) — review only the 4 commits after `fd284d2`. Once those merge, this PR's diff reduces to just the backports.

## What

Comparing shen-cl against the canonical S41.1 distribution from [shenlanguage.org](https://shenlanguage.org/download.html) (Mark Tarver's Windows SBCL port) surfaced four things the official port has that shen-cl lacked:

- **`thread`/`terminate` natives on SBCL** (`SB-THREAD` wrappers, registered via `update-lambda-table` like the official `install.lsp` does). The kernel's concurrency library (`kernel/lib/concurrency`) now loads and runs — previously it had no platform hooks to call.
- **`(length X)` compiles to `LIST-LENGTH`** instead of the kernel's recursive `length`, matching the official backend's `cl.optimise-application`. Locked in with a golden compiler test.
- **`absvector` initializes elements to the `(fail)` sentinel**, matching the official port and Shen/Scheme, so `<-vector` on an unset slot of a raw absvector signals "vector element not found" instead of returning whatever `MAKE-ARRAY` leaves there. The sentinel is obtained by calling `(fail)` at allocation time (like the existing `vector` override) so it can never desync from the kernel's symbol regardless of how the precompiled tree was serialized.
- **`pos`, `tlstr`, `n->string`, `string->n` validate their arguments** and signal the official port's descriptive errors (e.g. `"ab" is not a unit string`) instead of leaking raw CL conditions.

## Testing

Full cycle on SBCL: `make precompile` → `make build-sbcl` → `make test-sbcl` (all 35 sections, 100% pass rate) → `make test-compiler` (all pass, including the new `length` golden test). Also smoke-tested end to end: concurrency library loads, `(thread (freeze ...))` computes on a real thread, `terminate` returns its thread, `thread` works as a first-class arity-1 function, and all four validated primitives produce the official error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
