### PR TITLE
Compiler optimisations: literal-test folding, direct thaw calls, enforced compiler tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Test
         run: make test-sbcl
 
+      - name: Compiler tests
+        run: make test-compiler
+
       - name: Package
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,17 @@ test-sbcl:
 	$(RunSBCL) $(Tests)
 
 #
+# Compiler unit tests (golden KL->Lisp output; implementation-independent).
+# Exits non-zero on any failure. Runs on the SBCL build (the reference impl).
+#
+
+CompilerTests=eval -l scripts/run-compiler-tests.shen
+
+.PHONY: test-compiler
+test-compiler:
+	$(RunSBCL) $(CompilerTests)
+
+#
 # Run an implementation
 #
 

--- a/scripts/run-compiler-tests.shen
+++ b/scripts/run-compiler-tests.shen
@@ -15,9 +15,12 @@
 
   _ Y -> Y)
 
+(set *compiler-test-failures* 0)
+
 (define assert-equal-h
   Exp X X -> (pr (make-string "[OK]    ~A = ~R ~%" Exp X))
-  Exp X Y -> (pr (make-string "[ERROR] ~A = ~R ~%  got ~R~%" Exp Y X)))
+  Exp X Y -> (do (set *compiler-test-failures* (+ 1 (value *compiler-test-failures*)))
+                 (pr (make-string "[ERROR] ~A = ~R ~%  got ~R~%" Exp Y X))))
 
 (define assert-equal
   Exp X Y -> (assert-equal-h Exp X (subst-vars X Y)))
@@ -35,3 +38,8 @@
 
 (load "src/compiler.shen")
 (load "tests/compiler-tests.shen")
+
+(let Failures (value *compiler-test-failures*)
+  (if (= Failures 0)
+      (do (output "~%All compiler tests passed.~%") (cl.exit 0))
+      (do (output "~%~A compiler test(s) FAILED.~%" Failures) (cl.exit 1))))

--- a/src/compiler.shen
+++ b/src/compiler.shen
@@ -111,7 +111,23 @@
 
 (define subst*
   X X Body -> Body
+  \\ The Shen variable NIL is represented as the empty list, which is also
+  \\ every list's spine terminator. The kernel `subst` can't tell the two
+  \\ apart, so it would clobber terminators into an improper list. Replace
+  \\ position-aware instead: only `[]` in element positions becomes the var.
+  X [] Body -> (subst-nil-element X Body)
   X Y Body -> (subst X Y Body))
+
+\\ Walk a list spine, substituting `[]` elements with V but preserving the
+\\ terminating `[]` (mutually recursive with subst-nil-element).
+(define subst-nil-spine
+  _ [] -> []
+  V [Hd | Tl] -> [(subst-nil-element V Hd) | (subst-nil-spine V Tl)])
+
+(define subst-nil-element
+  V [] -> V
+  V [Hd | Tl] -> (subst-nil-spine V [Hd | Tl])
+  _ X -> X)
 
 (define ch-T/NIL
   X -> (cl safe-t) where (= (protect T) X)

--- a/src/compiler.shen
+++ b/src/compiler.shen
@@ -130,7 +130,9 @@
        (compile-expression ChBody [ChVar | Scope])]))
 
 (define emit-if
-  Test Then Else Scope
+  true  Then _    Scope -> (compile-expression Then Scope)
+  false _    Else Scope -> (compile-expression Else Scope)
+  Test  Then Else Scope
   -> [(cl if) (optimise-boolean-check (compile-expression Test Scope))
               (compile-expression Then Scope)
               (compile-expression Else Scope)])
@@ -140,6 +142,10 @@
 
 (define emit-cond-clauses
   [] _ -> []
+  \\ A literal-false test never fires: drop the clause.
+  [[false _] | Rest] Scope -> (emit-cond-clauses Rest Scope)
+  \\ A literal-true test always fires: emit it and drop the dead tail.
+  [[true Body] | _] Scope -> [[(cl t) (compile-expression Body Scope)]]
   [[Test Body] | Rest] Scope
   -> (let CompiledTest (optimise-boolean-check (compile-expression Test Scope))
           CompiledBody (compile-expression Body Scope)

--- a/src/compiler.shen
+++ b/src/compiler.shen
@@ -57,6 +57,9 @@
                           (compile-expression E1 Scope)
                           (compile-expression E2 Scope)])
   [= A B] Scope -> (emit-equality-check A B Scope)
+  \\ (thaw Exp) is a zero-arg application of the thunk: call it directly
+  \\ rather than routing through the `thaw` function (ported from Shen/Scheme).
+  [thaw Exp] Scope -> [(cl funcall) (compile-expression Exp Scope)]
   [intern S] _ -> [(cl quote) (intern S)] where (string? S)
   [type Exp _] Scope -> (compile-expression Exp Scope)
   [lisp.lambda Vars Body] Scope -> [(cl lambda) Vars (compile-expression Body (append Vars Scope))]

--- a/tests/compiler-tests.shen
+++ b/tests/compiler-tests.shen
@@ -174,6 +174,22 @@
      [[(shen-cl.cl null) [(shen-cl.cl quote) val]] 0]
      [(shen-cl.cl t) 3]])
 
+\\ Constant-test folding: an `if` with a literal true/false test collapses
+\\ to the taken branch (ported from Shen/Scheme's emit-if).
+(assert-equal
+ (shen-cl.kl->lisp [if true 1 2])
+ 1)
+
+(assert-equal
+ (shen-cl.kl->lisp [if false 1 2])
+ 2)
+
+\\ In a cond, a literal-false clause is dropped and a literal-true clause is
+\\ emitted as the CL `t` fallthrough, dropping any (dead) trailing clauses.
+(assert-equal
+ (shen-cl.kl->lisp [cond [false 1] [true 2] [[> 1 2] 3]])
+ [(shen-cl.cl cond) [(shen-cl.cl t) 2]])
+
 (set shen-cl.*compiling-shen-sources* true)
 
 (assert-equal

--- a/tests/compiler-tests.shen
+++ b/tests/compiler-tests.shen
@@ -87,14 +87,14 @@
 
 (assert-equal
  (shen-cl.kl->lisp [trap-error [+ 1 2] [lambda E 0]])
- [(shen-cl.kl trap-error) [(shen-cl.kl shen-cl.add) 1 2]
+ [(shen-cl.kl trap-error) [(shen-cl.cl (intern "1+")) 2]
    [(shen-cl.kl lambda) E 0]])
 
 (define default D E -> D)
 
 (assert-equal
  (shen-cl.kl->lisp [trap-error [+ 1 2] [default 0]])
- [(shen-cl.kl trap-error) [(shen-cl.kl shen-cl.add) 1 2]
+ [(shen-cl.kl trap-error) [(shen-cl.cl (intern "1+")) 2]
    [(shen-cl.cl funcall) [(shen-cl.kl lambda) X [(shen-cl.kl lambda) Y [(shen-cl.qualify-op default) X Y]]] 0]])
 
 (assert-equal
@@ -164,12 +164,12 @@
 
 (assert-equal
  (shen-cl.kl->lisp [if [= 1 2] 1 2])
- [(shen-cl.cl if) [(shen-cl.cl eql) 1 2] 1 2])
+ [(shen-cl.cl if) [(shen-cl.cl equalp) 1 2] 1 2])
 
 (assert-equal
  (shen-cl.kl->lisp [cond [[= 1 2] 1] [[> 1 2] 2] [[= [] val] 0] [true 3]])
  [(shen-cl.cl cond)
-     [[(shen-cl.cl eql) 1 2] 1]
+     [[(shen-cl.cl equalp) 1 2] 1]
      [[(shen-cl.cl >) 1 2] 2]
      [[(shen-cl.cl null) [(shen-cl.cl quote) val]] 0]
      [(shen-cl.cl t) 3]])

--- a/tests/compiler-tests.shen
+++ b/tests/compiler-tests.shen
@@ -190,6 +190,18 @@
  (shen-cl.kl->lisp [cond [false 1] [true 2] [[> 1 2] 3]])
  [(shen-cl.cl cond) [(shen-cl.cl t) 2]])
 
+\\ (thaw Exp) compiles to a direct funcall of the thunk, not a call through
+\\ the `thaw` function (ported from Shen/Scheme).
+(assert-equal
+ (shen-cl.kl->lisp [thaw F])
+ [(shen-cl.cl funcall) [(shen-cl.cl quote) F]])
+
+\\ A chain of `cons` calls forming a proper list collapses to a single
+\\ `list` call (already done by optimise-static-application; locked in here).
+(assert-equal
+ (shen-cl.kl->lisp [cons 1 [cons 2 []]])
+ [(shen-cl.cl list) 1 2])
+
 (set shen-cl.*compiling-shen-sources* true)
 
 (assert-equal


### PR DESCRIPTION
**Stacked on #58** — review only the 5 commits after `296bc07`. Once #58 merges, this PR's diff reduces to just the compiler work.

Pulled out of #58 per review feedback to keep that PR revival-only.

- Fold `if`/`cond` branches with literal `true`/`false` tests (dead-branch elimination, ported from Shen/Scheme's `emit-if`).
- Compile `(thaw X)` to a direct `FUNCALL` of the thunk instead of routing through the `thaw` function (ported from Shen/Scheme).
- Fix a crash compiling `(let NIL ...)` / `(lambda NIL ...)` — the Shen variable `NIL` collides with CL's list terminator; substitution is now position-aware.
- Golden KL→Lisp compiler tests refreshed and enforced: fail-loud harness, `make test-compiler` target, and a CI step.

Tested with `make test-sbcl` (full kernel suite, 100%) and `make test-compiler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
