### PR TITLE
Target ShenOSKernel-41.2

### DIFF
--- a/.github/workflows/port-tests.yml
+++ b/.github/workflows/port-tests.yml
@@ -1,0 +1,63 @@
+name: Port Tests
+
+# Port-authored test suites (ADDITIVE; distinct from the canonical kernel
+# certification suite). Builds shen-cl on SBCL, then runs:
+#   - make test-compiler : existing KL->Lisp compiler-output golden tests
+#   - make test-port     : tests/*-tests.shen runtime regression suite
+#   - make test-cli      : scripts/test-cli.sh CLI/launcher parity (SBCL here;
+#                          locally it also exercises clisp + ecl when built)
+# It does NOT run the canonical kernel suite (that lives in the release CI's
+# `make test-sbcl`) and does NOT modify any canonical target.
+
+on:
+  push:
+    branches: [ main, 'kernel-*' ]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # shen-cl is self-hosting; building it requires an existing Shen kernel
+  # executable to precompile the kernel + compiler down to Lisp. We bootstrap
+  # from a previously released prebuilt binary, matching release.yml.
+  BOOTSTRAP_REPO: pyrex41/shen-cl
+  BOOTSTRAP_TAG: v3.0.4
+
+jobs:
+  port-tests:
+    name: Port tests (SBCL)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SBCL
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sbcl curl
+
+      - name: Fetch ShenOSKernel
+        run: make fetch
+
+      - name: Download bootstrap Shen
+        shell: bash
+        run: |
+          mkdir -p bootstrap
+          URL="https://github.com/${BOOTSTRAP_REPO}/releases/download/${BOOTSTRAP_TAG}/shen-cl-${BOOTSTRAP_TAG}-linux-x86_64-prebuilt.tar.gz"
+          echo "Bootstrapping from $URL"
+          curl -fsSL -o bootstrap/boot.tar.gz "$URL"
+          tar xzf bootstrap/boot.tar.gz -C bootstrap
+          BOOT_SHEN="$(find "$PWD/bootstrap" -name shen -type f | head -n1)"
+          chmod +x "$BOOT_SHEN"
+          echo "BOOT_SHEN=$BOOT_SHEN" >> "$GITHUB_ENV"
+
+      - name: Precompile kernel + compiler
+        run: make precompile SHEN="$BOOT_SHEN"
+
+      - name: Build shen-cl (SBCL)
+        run: make build-sbcl
+
+      - name: Compiler tests (existing)
+        run: make test-compiler
+
+      - name: Port runtime tests
+        run: make test-port
+
+      - name: CLI / launcher parity tests
+        run: make test-cli

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ release/
 .DS_Store
 .claude/
 compiled/
+# Scratch files written by the port-authored test suites (tests/io-tests.shen,
+# scripts/test-cli.sh); recreated on every run.
+tests/*.tmp

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 # Set shared variables
 #
 
-KernelVersion=41.1
+KernelVersion=41.2
 
 UrlRoot=https://github.com/Shen-Language/shen-sources/releases/download
 KernelTag=shen-$(KernelVersion)

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,34 @@ test-compiler:
 	$(RunSBCL) $(CompilerTests)
 
 #
+# Port-authored test suites (ADDITIVE; distinct from the canonical kernel
+# certification suite run by test-{clisp,ccl,ecl,sbcl} and from the KL->Lisp
+# compiler-output tests run by test-compiler -- none of which this touches).
+#
+#   test-port : runtime regression suite (tests/*-tests.shen) on the reference
+#               SBCL build. Mirrors shen-go's kl/*_test.go categories
+#               (primitives, io, error catchability, reader, library).
+#   test-cli  : CLI/launcher parity (scripts/test-cli.sh) -- drives the built
+#               shen binary across sbcl/clisp/ecl for multi-impl parity,
+#               skipping any impl whose binary is absent. Mirrors shen-go's
+#               cmd/shen/main_test.go.
+#   test-all  : the canonical SBCL suite + compiler tests + the two above.
+#
+
+PortTests=eval -l scripts/run-port-tests.shen
+
+.PHONY: test-port
+test-port:
+	$(RunSBCL) $(PortTests)
+
+.PHONY: test-cli
+test-cli:
+	bash scripts/test-cli.sh
+
+.PHONY: test-all
+test-all: test-sbcl test-compiler test-port test-cli
+
+#
 # Run an implementation
 #
 

--- a/scripts/run-port-tests.shen
+++ b/scripts/run-port-tests.shen
@@ -1,0 +1,28 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Driver for the port-authored RUNTIME test suite (distinct from the canonical
+\\ kernel certification suite and from the KL->Lisp compiler-output tests).
+\\ Loads the shared harness, then every tests/*-tests.shen runtime file, then
+\\ reports a pass/fail tally and exits non-zero on any failure.
+\\
+\\ Run on the reference SBCL build via `make test-port`:
+\\   bin/sbcl/shen eval -l scripts/run-port-tests.shen
+\\
+\\ We set *hush* true so load's per-form echo does not flood the pipe (on the
+\\ CLISP build a flooded pipe can race (cl.exit) and yield a spurious non-zero
+\\ exit). assert= is silent on success; the io suite toggles *hush* locally
+\\ around its pr-to-file probes; and port-test-report clears *hush* before it
+\\ prints the summary and exits, so the result is deterministic on SBCL, CLISP
+\\ and ECL whether or not the CLI -q flag is also passed.
+
+(set *hush* true)
+
+(load "tests/test-harness.shen")
+(load "tests/primitives-tests.shen")
+(load "tests/io-tests.shen")
+(load "tests/error-tests.shen")
+(load "tests/reader-tests.shen")
+(load "tests/library-tests.shen")
+
+(port-test-report "port runtime tests")

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# Port-authored CLI / launcher integration tests (DISTINCT from the canonical
+# kernel certification suite and from the KL->Lisp compiler-output tests).
+#
+# Mirrors shen-go's cmd/shen/main_test.go, translated to a shell harness that
+# drives the BUILT shen binary:
+#   - eval -e EXPR           prints the value
+#   - eval -l FILE -e EXPR   loads a file then evaluates
+#   - script FILE A B        runs a script with *argv* = [FILE A B]
+#   - eval -q ... (pr S)     quiet mode still writes pr to FILE streams (the
+#                            ratatoskr stage-1 regression) -- see notes re CLISP
+#   - --version / --help     metadata
+#   - bad subcommand         prints an Invalid argument error
+#   - piped stdin EOF        bounded so a non-exiting REPL cannot hang CI
+#   - the port .shen runtime suite (scripts/run-port-tests.shen)
+#
+# CRITICAL shen-cl-unique value: every check runs across LISP_IMPL in
+# {sbcl, clisp, ecl}. Whichever binaries are built are exercised for
+# MULTI-IMPLEMENTATION PARITY (same program, same observable output); a missing
+# impl is skipped gracefully. SBCL is the reference impl and is required.
+#
+# Documented cross-impl DIVERGENCES locked in below (not faked parity):
+#   * piped-stdin EOF: shen-go's REPL exits cleanly on EOF; the shen-cl /
+#     Shen-41.x REPL LOOPS forever on stdin EOF (a known kernel gotcha -- the
+#     supported clean exit is (cl.exit)). We assert the documented clean-exit
+#     path works and that an EOF'd REPL is bounded by a timeout, rather than
+#     asserting shen-go's clean-EOF behaviour the port does not have.
+#   * bad subcommand: shen-go exits non-zero; the shen-cl launcher prints
+#     "Invalid argument" but exits 0. We assert the message (the real contract).
+#   * quiet (-q) pr-to-file: SBCL writes pr to file streams regardless of -q;
+#     the CLISP build SILENCES pr to file streams under -q (write-byte is
+#     unaffected on both). We assert per-impl accordingly.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# A bounded runner so a non-exiting REPL can never hang CI. Prefer GNU/coreutils
+# timeout; fall back to gtimeout (macOS+brew); else run unbounded.
+#
+# The Shen REPL on these Lisp runtimes does NOT exit on its own SIGTERM (it has
+# its own signal handling), so a plain `timeout` would itself hang waiting for
+# a process that ignores the soft kill. We pass `-k <grace>` so timeout escalates
+# to SIGKILL after the grace period, guaranteeing termination. NOTE: with -k,
+# GNU timeout reports the SIGKILL escalation as exit 137 (128+9), whereas a
+# process that honours the soft SIGTERM yields 124; callers treat both as "the
+# bound fired" for the bare-EOF probe.
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout"; fi
+run_bounded() { # SECS CMD...
+  local secs="$1"; shift
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" -k 3 "$secs" "$@"; else "$@"; fi
+}
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  [OK]    $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  [FAIL]  $1"; }
+
+# assert that "$2" (haystack) contains "$1" (needle)
+assert_contains() { # NEEDLE HAYSTACK LABEL
+  case "$2" in
+    *"$1"*) ok "$3" ;;
+    *)      bad "$3 -- expected to contain [$1], got:"; printf '%s\n' "$2" | sed 's/^/          | /' ;;
+  esac
+}
+assert_eq() { # EXPECTED ACTUAL LABEL
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 -- expected [$1] got [$2]"; fi
+}
+
+# Resolve the launcher invocation for an impl, or empty string if not built.
+shen_bin() { # IMPL
+  case "$1" in
+    sbcl)  [ -x bin/sbcl/shen ]  && echo "bin/sbcl/shen" ;;
+    clisp) [ -x bin/clisp/shen ] && echo "bin/clisp/shen --clisp-m 10MB" ;;
+    ecl)   [ -x bin/ecl/shen ]   && echo "bin/ecl/shen" ;;
+  esac
+}
+
+test_impl() { # IMPL
+  local impl="$1"
+  local bin; bin="$(shen_bin "$impl")"
+  if [ -z "$bin" ]; then
+    echo "== $impl: binary not built, skipping =="
+    return 0
+  fi
+  echo "== $impl ($bin) =="
+
+  local tmp out ec
+  tmp="$(mktemp -d)"
+
+  # --- eval -e EXPR prints the value ---
+  out="$(run_bounded 60 $bin eval -e '(+ 1 2)' 2>&1)"
+  assert_contains "3" "$out" "$impl: eval -e prints value"
+
+  # --- eval -l FILE -e EXPR loads then evaluates ---
+  printf '(define dbl X -> (* 2 X))' > "$tmp/load.shen"
+  out="$(run_bounded 60 $bin eval -l "$tmp/load.shen" -e '(dbl 21)' 2>&1)"
+  assert_contains "42" "$out" "$impl: eval -l FILE then -e"
+
+  # --- script FILE A B sets *argv* = [FILE A B] ---
+  printf '(output "ARGV=~A~%%" (value *argv*))' > "$tmp/script.shen"
+  out="$(run_bounded 60 $bin script "$tmp/script.shen" alpha beta 2>&1)"
+  assert_contains "ARGV=[$tmp/script.shen alpha beta]" "$out" "$impl: script sets *argv*"
+
+  # --- --version / --help ---
+  # DIVERGENCE: on the CLISP build the underlying CLISP runtime intercepts the
+  # global flags --version and --help for ITSELF before the shen launcher sees
+  # them, so they cannot report shen's metadata. SBCL and ECL pass them through
+  # to the launcher. Assert per-impl rather than fake parity.
+  if [ "$impl" = "clisp" ]; then
+    echo "  [SKIP]  clisp: --version/--help intercepted by the CLISP runtime (divergence)"
+  else
+    out="$(run_bounded 60 $bin --version 2>&1)"
+    assert_contains "41.2" "$out" "$impl: --version reports kernel version"
+    out="$(run_bounded 60 $bin --help 2>&1)"
+    assert_contains "Usage:" "$out" "$impl: --help shows usage"
+    assert_contains "script" "$out" "$impl: --help lists the script command"
+  fi
+
+  # --- bad subcommand prints Invalid argument (DIVERGENCE: exit is 0) ---
+  out="$(run_bounded 60 $bin no-such-cmd x 2>&1)"; ec=$?
+  assert_contains "Invalid argument" "$out" "$impl: bad subcommand reports Invalid argument"
+  # Lock in the divergence: shen-cl returns 0 here (shen-go returns non-zero).
+  assert_eq "0" "$ec" "$impl: bad subcommand exit status (shen-cl returns 0)"
+
+  # --- adversarial eval -e exits non-zero, prints an error, no Lisp backtrace ---
+  # Route stdout/err to a FILE (not a pipe): the CLISP build cannot WRITE-CHAR
+  # its fatal-error message onto an unbuffered pipe (it raises "WRITE-CHAR ...
+  # is illegal" instead), so we capture via a regular file which all impls
+  # handle. The contract: non-zero exit + names the bad symbol + no backtrace.
+  run_bounded 60 $bin eval -e '(overflow->str)' > "$tmp/adv.out" 2>&1; ec=$?
+  out="$(cat "$tmp/adv.out")"
+  if [ "$ec" -ne 0 ]; then ok "$impl: adversarial eval exits non-zero"
+  else bad "$impl: adversarial eval should exit non-zero, got 0"; fi
+  # DIVERGENCE: the SBCL/ECL builds write the fatal-error message (which names
+  # the unbound symbol) to stdout. The CLISP build cannot WRITE-CHAR its error
+  # onto a non-TTY fd stream (it raises "WRITE-CHAR on ... /dev/fd/1 is
+  # illegal"), so the shen error text is unavailable there; we only assert the
+  # non-zero exit and no-backtrace contract for CLISP.
+  if [ "$impl" = "clisp" ]; then
+    echo "  [SKIP]  clisp: cannot render fatal-error text onto a non-TTY fd (divergence)"
+  else
+    assert_contains "overflow->str" "$out" "$impl: adversarial eval names the bad symbol"
+  fi
+  case "$out" in
+    *"Backtrace for"*|*"debugger invoked"*)
+      bad "$impl: adversarial eval leaked a Lisp backtrace:"; printf '%s\n' "$out" | sed 's/^/          | /' ;;
+    *) ok "$impl: adversarial eval did not leak a Lisp backtrace" ;;
+  esac
+
+  # --- quiet (-q) pr-to-file (the ratatoskr stage-1 regression + divergence) ---
+  # DIVERGENCE: under -q (which sets *hush*), only the SBCL build still writes
+  # (pr STR FileStream); the CLISP and ECL builds SILENCE pr to file streams
+  # (zero-byte file). (write-byte ... FileStream) is unaffected on ALL builds.
+  rm -f "$tmp/q.txt"
+  run_bounded 60 $bin eval -q -e \
+    "(let S (open \"$tmp/q.txt\" out) (do (pr \"payload\" S) (close S)))" >/dev/null 2>&1
+  local content=""; [ -f "$tmp/q.txt" ] && content="$(cat "$tmp/q.txt")"
+  case "$impl" in
+    sbcl)
+      assert_eq "payload" "$content" "$impl: -q does NOT suppress pr to a file stream" ;;
+    clisp|ecl)
+      assert_eq "" "$content" "$impl: -q silences pr to a file stream (CLISP/ECL divergence)" ;;
+  esac
+  # write-byte to a file is unaffected by -q on ALL impls (impl-independent).
+  rm -f "$tmp/wb.txt"
+  run_bounded 60 $bin eval -q -e \
+    "(let S (open \"$tmp/wb.txt\" out) (do (write-byte 90 S) (close S)))" >/dev/null 2>&1
+  local wb=""; [ -f "$tmp/wb.txt" ] && wb="$(cat "$tmp/wb.txt")"
+  assert_eq "Z" "$wb" "$impl: -q does NOT suppress write-byte to a file stream"
+
+  # --- piped stdin: the supported clean exit is (cl.exit) ---
+  # Capture via a FILE: a piped REPL on the CLISP build aborts its REPL driver
+  # frame when stdin is not a TTY ("reset() found no driver frame", SIGABRT
+  # 134) -- a documented CLISP-build divergence. SBCL/ECL exit 0 cleanly.
+  printf '(version)\n(cl.exit 0)\n' | run_bounded 30 $bin > "$tmp/repl.out" 2>&1; ec=$?
+  out="$(cat "$tmp/repl.out")"
+  assert_contains "41.2" "$out" "$impl: REPL evaluates a piped form"
+  if [ "$impl" = "clisp" ]; then
+    # 134 = SIGABRT from the no-driver-frame abort on a piped (non-TTY) REPL.
+    if [ "$ec" -eq 0 ] || [ "$ec" -eq 134 ]; then
+      ok "clisp: piped REPL exits (0 clean, or 134 driver-frame abort -- divergence)"
+    else
+      bad "clisp: piped REPL exited with unexpected status $ec"
+    fi
+  else
+    assert_eq "0" "$ec" "$impl: REPL exits 0 via (cl.exit)"
+  fi
+  # DIVERGENCE: a bare EOF (no cl.exit) does NOT exit the shen-cl/Shen-41.x REPL
+  # cleanly -- it loops (a known kernel gotcha), and the REPL also ignores the
+  # soft SIGTERM. Bound it so CI can't hang: run_bounded escalates to SIGKILL,
+  # so a firing bound shows as 124 (soft kill honoured), 137 (128+9 SIGKILL
+  # escalation) or 134 (CLISP SIGABRT on a piped REPL). Any of those means
+  # "the loop was bounded"; only a clean, prompt 0 would be a (welcome)
+  # divergence. An unbounded hang would deadline the whole run.
+  printf '(version)\n' | run_bounded 6 $bin >/dev/null 2>&1; ec=$?
+  if [ -z "$TIMEOUT_BIN" ]; then
+    echo "  [SKIP]  $impl: no timeout binary; not probing bare-EOF loop"
+  elif [ "$ec" -eq 124 ] || [ "$ec" -eq 137 ] || [ "$ec" -eq 134 ]; then
+    ok "$impl: bare-EOF REPL does not exit cleanly (bounded) -- documented divergence"
+  elif [ "$ec" -eq 0 ]; then
+    ok "$impl: bare-EOF REPL exited cleanly (better than documented)"
+  else
+    bad "$impl: bare-EOF REPL exited with unexpected status $ec"
+  fi
+
+  # --- the port .shen runtime suite, across this impl (parity) ---
+  # Exit code can flake on CLISP's buffered console at (cl.exit); the
+  # PORT-TESTS-PASS sentinel text is emitted reliably, so gate on that.
+  find tests -name '*.tmp' -delete 2>/dev/null || true
+  out="$(run_bounded 120 $bin eval -l scripts/run-port-tests.shen 2>&1)"
+  assert_contains "PORT-TESTS-PASS" "$out" "$impl: port .shen runtime suite passes"
+  case "$out" in
+    *PORT-TESTS-FAIL*) bad "$impl: port suite reported a failure:"; printf '%s\n' "$out" | grep -i fail | sed 's/^/          | /' ;;
+    *) : ;;
+  esac
+  find tests -name '*.tmp' -delete 2>/dev/null || true
+
+  rm -rf "$tmp"
+}
+
+echo "shen-cl port-authored CLI parity tests"
+echo "======================================"
+
+# SBCL is the reference impl and must be present.
+if [ -z "$(shen_bin sbcl)" ]; then
+  echo "ERROR: bin/sbcl/shen is not built; build with 'make build-sbcl' first." >&2
+  exit 2
+fi
+
+for impl in sbcl clisp ecl; do
+  test_impl "$impl"
+done
+
+echo "======================================"
+echo "CLI parity: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/src/overwrite.lsp
+++ b/src/overwrite.lsp
@@ -280,11 +280,36 @@
       -1
       (char-int c))))
 
-#+(or ccl sbcl)
+;; Native pr: write the string to the stream unconditionally, never
+;; consulting *hush*. The kernel's KL pr (writer.kl) returns early without
+;; writing whenever *hush* is true -- which wrongly silences pr to FILE
+;; streams under -q (e.g. `eval -q -e "(pr ... FileStream)"`), producing a
+;; zero-byte file. SBCL/CCL already bypassed the KL pr via this override;
+;; ECL ran the KL pr and so silenced pr to files under -q. Its file streams
+;; are character streams, so the same write-string override applies.
+;; Extending the override to ECL makes SBCL/CCL/ECL agree: pr writes to its
+;; target stream regardless of *hush* (Shen issue #2).
+#+(or ccl sbcl ecl)
 (defun |pr| (x s)
   (write-string x s)
   (when (or (eq s |*stoutput*|) (eq s |*stinput*|))
     (force-output s))
+  x)
+
+;; CLisp file streams are opened with :element-type 'unsigned-byte (see
+;; |shen.openh| in primitives.lsp), so write-string is illegal on them; the
+;; kernel's KL pr dispatches such streams to a write-byte path. Mirror that
+;; dispatch here but, like the SBCL/CCL/ECL override, ignore *hush* so pr to
+;; a file stream is never silenced under -q (Shen issue #2). Character streams
+;; (e.g. *stoutput*) still take write-string.
+#+clisp
+(defun |pr| (x s)
+  (if (subtypep (stream-element-type s) 'character)
+      (progn
+        (write-string x s)
+        (when (or (eq s |*stoutput*|) (eq s |*stinput*|))
+          (force-output s)))
+      (loop for c across x do (write-byte (char-code c) s)))
   x)
 
 ;; file reading

--- a/src/primitives.lsp
+++ b/src/primitives.lsp
@@ -137,12 +137,26 @@
 (defmacro |freeze| (x)
   `(function (lambda () ,x)))
 
+;; Sanity cap on absvector size (Shen issue #3). Without it, (absvector HUGE)
+;; asks make-array for an array far larger than the heap, which SBCL reports as
+;; an *uncatchable* "Heap exhausted" abort -- trap-error cannot recover from it,
+;; so a single bad size takes down the whole image. The cap is ~16.7 million
+;; slots (2^24), which is over 800x the largest vector the kernel itself ever
+;; allocates (the 20000-slot property dictionary), so it cannot break any
+;; legitimate kernel or program use; anything beyond it raises a catchable Shen
+;; error instead of crashing. shen-go applies the same kind of cap.
+(defconstant |shen-cl.max-absvector-size| (expt 2 24))
+
 ;; Elements start as the fail sentinel so that reading an unset slot via
 ;; <-vector signals "not found", matching the official S41.1 port and
 ;; Shen/Scheme. (|fail|) is kernel-defined and only called at runtime,
 ;; after the kernel has loaded.
 (defun |absvector| (n)
-  (make-array n :initial-element (|fail|)))
+  (if (and (integerp n) (>= n 0) (<= n |shen-cl.max-absvector-size|))
+      (make-array n :initial-element (|fail|))
+      (|simple-error|
+        (format nil "absvector size ~A out of range (0..~A)~%"
+                n |shen-cl.max-absvector-size|))))
 
 (defun |absvector?| (x)
   (if (and (arrayp x) (not (stringp x)))

--- a/tests/error-tests.shen
+++ b/tests/error-tests.shen
@@ -1,0 +1,76 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored error-CATCHABILITY contract. Mirrors shen-go's
+\\ kl/error_robustness_test.go: every documented error path must
+\\   (1) be catchable via (trap-error ...),
+\\   (2) for the stable, implementation-independent messages, surface that
+\\       message verbatim, and
+\\   (3) leave the interpreter state clean enough that the next eval succeeds.
+\\
+\\ shen-go pins exact Go-side messages and tests two eval paths (tree-walker +
+\\ bytecode VM). shen-cl compiles everything to Common Lisp, so there is no
+\\ second eval path to mirror, and the underlying error text for most paths is
+\\ CL-specific (e.g. "The variable |X| is unbound."). We therefore assert
+\\ CATCHABILITY for the CL-specific paths and pin the verbatim message only for
+\\ paths whose text the Shen kernel itself controls (simple-error passthrough,
+\\ the unit-string error). This locks in the real contract without faking
+\\ message parity. Loaded after tests/test-harness.shen by run-port-tests.shen.
+
+\\ --- (1) every documented error path is catchable ---
+(assert-caught "apply unbound symbol"
+               (freeze (overflow->str)))
+(assert-caught "apply undefined function with args"
+               (freeze (undefined-fn-xyz 1)))
+(assert-caught "value of unbound variable"
+               (freeze (value never-bound-xyz)))
+(assert-caught "if requires a boolean"
+               (freeze (if 42 1 2)))
+(assert-caught "explicit simple-error"
+               (freeze (simple-error "boom")))
+(assert-caught "arithmetic on non-number"
+               (freeze (+ 1 foo)))
+(assert-caught "divide by zero"
+               (freeze (/ 1 0)))
+(assert-caught "string->n of empty string"
+               (freeze (string->n "")))
+(assert-caught "vector index out of range"
+               (freeze (<-address (absvector 3) 99)))
+
+\\ --- (2) stable, kernel-controlled messages surface verbatim ---
+(assert-msg "simple-error message passthrough" "boom"
+            (freeze (simple-error "boom")))
+\\ The unit-string error's text begins with two literal double-quote chars and
+\\ (in shen-cl) ends with a trailing newline; build the expected string with
+\\ (n->string 34) for the quote and (n->string 10) for the newline since the
+\\ Shen reader has no escape for either inside a literal.
+(assert-msg "unit-string error message"
+            (@s (n->string 34)
+                (@s (n->string 34)
+                    (@s " is not a unit string" (n->string 10))))
+            (freeze (string->n "")))
+
+\\ --- (3) interpreter state stays clean across an adversarial sequence ---
+\\ Mirrors shen-go's TestEvalSurvivesAdversarialSequence: drive several errors
+\\ in a row, then assert a plain arithmetic form still evaluates correctly.
+(define err-survives
+  -> (do (trap-error (overflow->str) (lambda E ignore))
+         (trap-error (value never-bound-xyz) (lambda E ignore))
+         (trap-error (if 42 1 2) (lambda E ignore))
+         (trap-error (simple-error "boom") (lambda E ignore))
+         (trap-error (undefined-fn-xyz 1) (lambda E ignore))
+         (+ 40 2)))
+
+(assert= "eval survives adversarial sequence" 42 (err-survives))
+
+\\ A caught error's handler value is returned (the trap-error result IS an Obj,
+\\ not a stray panic payload -- the shen-go SIGSEGV regression analogue).
+(assert= "trap-error returns handler value"
+         recovered
+         (trap-error (overflow->str) (lambda E recovered)))
+
+\\ error-to-string round-trips an explicit error object.
+(assert= "error-to-string of simple-error"
+         "specific message"
+         (error-to-string (trap-error (simple-error "specific message")
+                                      (lambda E E))))

--- a/tests/io-tests.shen
+++ b/tests/io-tests.shen
@@ -1,0 +1,82 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored IO regression suite. Mirrors shen-go's kl/io_coverage_test.go:
+\\ open (in/out), close, a write-byte -> close -> read-byte round trip,
+\\ read-byte at EOF returning -1, read-file-as-string and read-file-as-bytelist.
+\\
+\\ Files are written under a repo-relative path so the run is self-contained;
+\\ *home-directory* is "" in the built image, so the path passes through open
+\\ unchanged. Loaded after tests/test-harness.shen by run-port-tests.shen.
+\\
+\\ CROSS-IMPL *hush* DIVERGENCE (verified, locked in below): with *hush* = true,
+\\ (pr STR FileStream) is SILENCED on the CLISP build (it produces a zero-byte
+\\ file) but written on the SBCL build. (write-byte ... FileStream) is written
+\\ on BOTH regardless of *hush*. The port test runner loads under *hush* = true
+\\ for quiet output, so these pr-based round trips explicitly clear *hush*
+\\ first; otherwise the CLISP run would read back empty files.
+
+(set *hush* false)
+
+\\ --- write-byte -> close -> read-byte round trip + EOF (-1) ---
+\\ Mirrors shen-go's TestStreamRoundTrip: write "Hi" (72 105), read back the
+\\ two bytes then -1 at EOF.
+(define io-roundtrip
+  Path -> (let Out (open Path out)
+               _ (write-byte 72 Out)
+               _ (write-byte 105 Out)
+               _ (close Out)
+               In (open Path in)
+               B1 (read-byte In)
+               B2 (read-byte In)
+               Eof (read-byte In)
+               _ (close In)
+            (@p B1 (@p B2 Eof))))
+
+(assert= "stream round trip + EOF"
+         (@p 72 (@p 105 -1))
+         (io-roundtrip "tests/io-roundtrip.tmp"))
+
+\\ --- read-file-as-string + read-file-as-bytelist against a real file ---
+\\ Mirrors shen-go's TestFileReadPrimitives ("AB" -> "AB" and (65 66)).
+(define io-write-text
+  Path Text -> (let Out (open Path out)
+                    _ (pr Text Out)
+                 (close Out)))
+
+(assert= "read-file-as-string"
+         "AB"
+         (do (io-write-text "tests/io-readfile.tmp" "AB")
+             (read-file-as-string "tests/io-readfile.tmp")))
+
+(assert= "read-file-as-bytelist"
+         [65 66]
+         (read-file-as-bytelist "tests/io-readfile.tmp"))
+
+\\ --- close on a fresh out-stream then reading it back is consistent ---
+\\ (open out truncates; an immediately-closed empty stream reads EOF first).
+(assert= "empty stream reads EOF"
+         -1
+         (let Out (open "tests/io-empty.tmp" out)
+              _ (close Out)
+              In (open "tests/io-empty.tmp" in)
+              B (read-byte In)
+              _ (close In)
+           B))
+
+\\ Lock in the *hush*/pr-to-file divergence as an explicit assertion:
+\\ under *hush* = true, (pr ... FileStream) writes on SBCL but is silenced on
+\\ CLISP; (write-byte ... FileStream) writes on BOTH. We assert only the
+\\ impl-independent fact -- write-byte is never silenced by *hush* -- so this
+\\ holds across SBCL/CLISP/ECL.
+(assert= "write-byte ignores *hush*"
+         [88]
+         (let _ (set *hush* true)
+              Out (open "tests/io-hush.tmp" out)
+              _ (write-byte 88 Out)
+              _ (close Out)
+              _ (set *hush* false)
+           (read-file-as-bytelist "tests/io-hush.tmp")))
+
+\\ Restore the quiet flag the runner relies on for the remaining suites.
+(set *hush* true)

--- a/tests/library-tests.shen
+++ b/tests/library-tests.shen
@@ -1,0 +1,49 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored stdlib suite. Mirrors shen-go's kl/library_test.go: the
+\\ standard list functions (reverse/append/map/element?/...) behave correctly,
+\\ including nested-list and empty-list edge cases.
+\\
+\\ Loaded after tests/test-harness.shen by run-port-tests.shen.
+
+\\ --- reverse (incl. nested + empty, mirroring shen-go's TestReverse) ---
+(assert= "reverse list"        [3 2 1]      (reverse [1 2 3]))
+(assert= "reverse empty"       []           (reverse []))
+(assert= "reverse nested"      [d [b c] a]  (reverse [a [b c] d]))
+(assert= "reverse roundtrip"   [1 2 3]      (reverse (reverse [1 2 3])))
+
+\\ --- append ---
+(assert= "append two lists"    [1 2 3 4]    (append [1 2] [3 4]))
+(assert= "append empty left"   [1]          (append [] [1]))
+(assert= "append empty right"  [1]          (append [1] []))
+
+\\ --- map / mapcan ---
+(assert= "map square"          [1 4 9]      (map (lambda X (* X X)) [1 2 3]))
+(assert= "map empty"           []           (map (lambda X (+ X 1)) []))
+(assert= "mapcan flatten"      [1 1 2 2]    (mapcan (lambda X [X X]) [1 2]))
+
+\\ --- element? ---
+(assert-true  "element? present" (element? 2 [1 2 3]))
+(assert-false "element? absent"  (element? 9 [1 2 3]))
+(assert-false "element? in empty" (element? a []))
+
+\\ --- length / nth (1-indexed) ---
+(assert= "length"   4 (length [1 2 3 4]))
+(assert= "length 0" 0 (length []))
+(assert= "nth 1"    a (nth 1 [a b c d]))
+(assert= "nth 3"    c (nth 3 [a b c d]))
+
+\\ --- union ---
+(assert= "union dedups" [1 2 3 4] (union [1 2 3] [2 3 4]))
+
+\\ --- occurrences ---
+(assert= "occurrences" 3 (occurrences 1 [1 2 1 3 1]))
+
+\\ --- tuples: @p / fst / snd ---
+(assert= "fst of tuple" 1 (fst (@p 1 2)))
+(assert= "snd of tuple" 2 (snd (@p 1 2)))
+
+\\ --- head / tail on a proper list ---
+(assert= "head" 1   (head [1 2 3]))
+(assert= "tail" [2 3] (tail [1 2 3]))

--- a/tests/primitives-tests.shen
+++ b/tests/primitives-tests.shen
@@ -1,0 +1,99 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored primitive regression suite. Mirrors shen-go's
+\\ kl/primitives_test.go + kl/primitives_coverage_test.go: ~50+ primitives
+\\ driven through ordinary evaluation -- arithmetic (incl. float comparisons),
+\\ string ops, symbols/globals, cons/hd/tl, absvector (incl. uninitialised and
+\\ out-of-range slots), type predicates, and get-time.
+\\
+\\ Loaded after tests/test-harness.shen by scripts/run-port-tests.shen.
+
+\\ --- arithmetic (integer + float) ---
+(assert= "add int" 8 (+ 5 3))
+(assert= "subtract int" 2 (- 5 3))
+(assert= "multiply int" 42 (* 6 7))
+(assert= "divide whole" 5 (/ 20 4))
+(assert= "divide fractional" 3.5 (/ 7 2))
+(assert= "subtract float" 3.5 (- 5.5 2.0))
+(assert= "multiply float" 4.5 (* 1.5 3.0))
+
+\\ float comparisons (mirrors shen-go's float comparison coverage)
+(assert-true  "gt float true"  (> 3.5 2.0))
+(assert-false "gt float false" (> 2.0 3.5))
+(assert-true  "lt float true"  (< 2.0 3.5))
+(assert-true  "ge float eq"    (>= 2.0 2.0))
+(assert-true  "le float eq"    (<= 2.0 2.0))
+(assert-true  "ge int"         (>= 5 3))
+(assert-false "le int false"   (<= 5 3))
+
+\\ --- list ops: cons / hd / tl ---
+(assert= "hd"          1     (hd (cons 1 (cons 2 ()))))
+(assert= "tl"          [2]   (tl (cons 1 (cons 2 ()))))
+(assert= "cons builds" [1 2] (cons 1 (cons 2 ())))
+\\ DIVERGENCE from shen-go: shen-go's (hd ())/(tl ()) RAISE "head/tail of nil".
+\\ shen-cl's kernel hd/tl of the empty list return [] (no error). Lock in the
+\\ shen-cl behaviour rather than fake parity.
+(assert= "hd of empty is []" [] (hd ()))
+(assert= "tl of empty is []" [] (tl ()))
+
+\\ --- type predicates ---
+(assert-true  "number? yes"    (number? 42))
+(assert-false "number? no"     (number? foo))
+(assert-true  "string? yes"    (string? "hi"))
+(assert-false "string? no"     (string? 1))
+(assert-true  "symbol? yes"    (symbol? hello))
+(assert-false "symbol? no"     (symbol? 1))
+(assert-true  "variable? upper" (variable? X))
+(assert-false "variable? lower" (variable? x))
+(assert-true  "cons? yes"      (cons? (cons 1 ())))
+(assert-false "cons? no"       (cons? 1))
+(assert-true  "absvector? yes" (absvector? (absvector 3)))
+(assert-false "absvector? no"  (absvector? 1))
+(assert-true  "empty? yes"     (empty? ()))
+(assert-false "empty? no"      (empty? (cons 1 ())))
+(assert-true  "tuple? yes"     (tuple? (@p 1 2)))
+(assert-false "boolean? num"   (boolean? 1))
+(assert-true  "boolean? true"  (boolean? true))
+
+\\ --- string ops ---
+(assert= "string->n"  65      (string->n "A"))
+(assert= "n->string"  "A"     (n->string 65))
+(assert= "cn"         "foobar" (cn "foo" "bar"))
+(assert= "@s"         "foobar" (@s "foo" "bar"))
+(assert= "tlstr"      "ello"  (tlstr "hello"))
+(assert= "pos"        "e"     (pos "hello" 1))
+(assert= "str number" "42"    (str 42))
+(assert= "str symbol" "foo"   (str foo))
+
+\\ --- symbols / globals: set then value ---
+(assert= "set returns value" 99 (set prim-test-global 99))
+(assert= "value reads global" 99 (value prim-test-global))
+(assert= "intern roundtrip" abc (intern "abc"))
+
+\\ --- absvector: set/get round trip, uninitialised + out-of-range slots ---
+(assert= "vector round trip" 7 (<-address (address-> (absvector 3) 1 7) 1))
+\\ Uninitialised slot: shen-cl initialises absvector slots to the symbol `fail!`
+\\ (the kernel's unfilled-slot marker). Assert that reading an untouched slot
+\\ does NOT crash and yields that marker (mirrors shen-go's undefined-slot case).
+(assert-no-crash "uninitialised slot no crash"
+                 (freeze (<-address (absvector 3) 0)))
+(assert= "uninitialised slot is fail!" (fail) (<-address (absvector 3) 0))
+\\ Out-of-range read is a catchable error (mirrors shen-go's TestVectorGet).
+(assert-caught "vector out-of-range read"
+               (freeze (<-address (absvector 3) 9)))
+
+\\ --- logic ---
+(assert-false "not true"  (not true))
+(assert-true  "not false" (not false))
+(assert-true  "and tt"    (and true true))
+(assert-false "and tf"    (and true false))
+(assert-true  "or ft"     (or false true))
+(assert-false "or ff"     (or false false))
+
+\\ --- get-time: both arms return numbers (mirrors shen-go's TestGetTime) ---
+(assert-true "get-time run is number" (number? (get-time run)))
+(assert-true "get-time unix is number" (number? (get-time unix)))
+
+\\ --- eval-kl (mirrors shen-go's TestEvalKL) ---
+(assert= "eval-kl builds + form" 7 (eval-kl (cons + (cons 3 (cons 4 ())))))

--- a/tests/reader-tests.shen
+++ b/tests/reader-tests.shen
@@ -1,0 +1,89 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored reader suite. Mirrors shen-go's kl/reader_test.go (well-formed
+\\ edge cases) and kl/reader_fuzz_test.go (seeded malformed input must NEVER
+\\ crash -- only parse, or raise a catchable error).
+\\
+\\ Reader entry point is (read-from-string S), which returns the LIST of forms
+\\ parsed from S. Several shen-go reader behaviours differ here and are locked
+\\ in as the documented shen-cl semantics (see the DIVERGENCE notes). Loaded
+\\ after tests/test-harness.shen by run-port-tests.shen.
+
+(define first-form
+  S -> (head (read-from-string S)))
+
+\\ --- well-formed atoms ---
+(assert= "read integer"  42      (first-form "42"))
+(assert= "read symbol"   symbol  (first-form "symbol"))
+(assert= "read true"     true    (first-form "true"))
+(assert= "read false"    false   (first-form "false"))
+\\ The argument to read-from-string must itself contain double-quote chars;
+\\ the Shen reader has no '\"' escape, so build "\"abc\"" via (n->string 34).
+(assert= "read string"   "abc"
+         (head (read-from-string (@s (n->string 34) (@s "abc" (n->string 34))))))
+
+\\ --- nested form evaluates correctly after reading ---
+(assert= "read+eval nested arithmetic" 7
+         (eval (first-form "(+ 1 (* 2 3))")))
+(assert= "read+eval nested if" 2
+         (eval (first-form "(if false 1 2)")))
+
+\\ DIVERGENCE from shen-go: in shen-go a paren form (a b c) reads as a plain
+\\ list. In shen-cl the reader lowers a paren application into the kernel's
+\\ CURRIED application AST, so (a b c) reads as [[[fn a] b] c]. Lock that in.
+(assert= "paren form is curried application AST"
+         [[[fn a] b] c]
+         (first-form "(a b c)"))
+
+\\ DIVERGENCE from shen-go: shen-go treats [a b c] as (list a b c). In shen-cl
+\\ bracket lists read as the unevaluated nested-cons AST (the documented
+\\ bracket-vs-paren gotcha), so [a b] -> [cons a [cons b []]].
+(assert= "bracket list is nested-cons AST"
+         [cons a [cons b []]]
+         (first-form "[a b]"))
+\\ ...and that AST, when evaluated, builds the list.
+(assert= "bracket list evaluates to a list"
+         [1 2 3]
+         (eval (first-form "[1 2 3]")))
+
+\\ DIVERGENCE from shen-go: shen-go's extended reader treats ';' as a line
+\\ comment. shen-cl uses '\\' for line comments (and ';' is an ordinary
+\\ symbol). Lock in BOTH facts.
+(assert= "backslash-backslash starts a line comment"
+         99
+         (first-form "\\\\ a comment line
+99"))
+(assert= "semicolon is an ordinary symbol"
+         ;
+         (first-form ";"))
+
+\\ --- seeded malformed-input no-crash contract (mirrors FuzzReaderEval) ---
+\\ For each seed, reading (and where parseable, evaluating) must TERMINATE
+\\ without taking down the process: a value or a catchable error, never a hard
+\\ crash. We probe via assert-no-crash over a frozen read[/eval] thunk.
+(assert-no-crash "empty input"        (freeze (read-from-string "")))
+(assert-no-crash "lone space"         (freeze (read-from-string " ")))
+(assert-no-crash "empty parens"       (freeze (read-from-string "()")))
+(assert-no-crash "open paren only"    (freeze (read-from-string "(")))
+(assert-no-crash "close paren only"   (freeze (read-from-string ")")))
+(assert-no-crash "unbalanced parens"  (freeze (read-from-string "((((")))
+(assert-no-crash "unterminated string"
+                 (freeze (read-from-string (@s (n->string 34) "unterminated"))))
+(assert-no-crash "garbage tokens"     (freeze (read-from-string "garbage !@# %^&")))
+(assert-no-crash "lambda underscore param read"
+                 (freeze (read-from-string "(/. _ false)")))
+(assert-no-crash "dollar form read"   (freeze (read-from-string "($ foo bar)")))
+\\ The witness-proofs repro: reading then EVALUATING illegal '_'-param lambda
+\\ must still terminate (catchable error, not a crash).
+(assert-no-crash "lambda underscore param read+eval"
+                 (freeze (eval (first-form "(/. _ false)"))))
+\\ DIVERGENCE from shen-go: shen-go's FuzzReaderEval includes
+\\ "(absvector 10000000000)" because PrimAbsvector there CAPS the requested
+\\ size and raises a catchable error. shen-cl's (absvector N) calls CL's
+\\ make-array with no kernel-side cap, so a pathological N is an unrecoverable
+\\ heap exhaustion, not a catchable Shen error -- we deliberately do NOT assert
+\\ catchability here (asserting it would fake parity and crash the run). A
+\\ modest oversize request still reads+evals fine:
+(assert-no-crash "modest absvector request"
+                 (freeze (eval (first-form "(absvector 1000)"))))

--- a/tests/test-harness.shen
+++ b/tests/test-harness.shen
@@ -1,0 +1,84 @@
+\* Copyright (c) 2026 shen-cl port authors.                          *\
+\* BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause *\
+
+\\ Port-authored runtime test harness (DISTINCT from the canonical kernel
+\\ certification suite under kernel/tests and from tests/compiler-tests.shen,
+\\ which checks KL->Lisp compiler output). This harness drives the *runtime*
+\\ behaviour of the built image through ordinary Shen evaluation and tallies
+\\ pass/fail, exiting non-zero on any failure so `make test-port` gates CI.
+\\
+\\ It mirrors, category-for-category, the shen-go port-authored Go test suite
+\\ (kl/primitives_*_test.go, io_coverage_test.go, error_robustness_test.go,
+\\ reader_*_test.go, library_test.go), translated idiomatically into Shen.
+
+(set *port-test-failures* 0)
+(set *port-test-count* 0)
+
+\\ mk-str: best-effort rendering of any value for failure diagnostics.
+(define mk-str
+  X -> (trap-error (make-string "~R" X) (lambda E "<unprintable>")))
+
+\\ assert= : assert Got equals Expected by value (=).
+\\ assert= prints ONLY on failure (so a green run is quiet and `load`'s
+\\ form-echo does not bury the final tally); the report prints the totals.
+(define assert=
+  Label Expected Got
+  -> (do (set *port-test-count* (+ 1 (value *port-test-count*)))
+         (if (= Expected Got)
+             true
+             (do (set *port-test-failures* (+ 1 (value *port-test-failures*)))
+                 (output "[FAIL]  ~A  expected ~A got ~A~%"
+                         Label (mk-str Expected) (mk-str Got))))))
+
+\\ assert-true / assert-false: boolean assertions.
+(define assert-true
+  Label Got -> (assert= Label true Got))
+
+(define assert-false
+  Label Got -> (assert= Label false Got))
+
+\\ assert-caught: run a frozen thunk under trap-error; PASS iff it raised an
+\\ error that the handler caught (returns the symbol `caught`). Used for the
+\\ error-catchability contract: we assert the error path is *catchable*, not
+\\ the exact (implementation-specific) Common Lisp message text.
+(define assert-caught
+  Label Thunk
+  -> (assert= Label caught (trap-error (do (thaw Thunk) not-caught)
+                                       (lambda E caught))))
+
+\\ assert-no-crash: run a frozen thunk; PASS iff evaluation TERMINATES without
+\\ taking down the process (returns a value OR raises a catchable error). This
+\\ is the Shen analogue of shen-go's reader/eval fuzz no-panic contract.
+(define assert-no-crash
+  Label Thunk
+  -> (assert= Label survived (trap-error (do (thaw Thunk) survived)
+                                         (lambda E survived))))
+
+\\ assert-msg: assert a caught error's message string equals Expected (for the
+\\ stable, implementation-independent messages such as simple-error passthrough).
+(define assert-msg
+  Label Expected Thunk
+  -> (assert= Label Expected (trap-error (do (thaw Thunk) "<<no-error>>")
+                                         (lambda E (error-to-string E)))))
+
+\\ Report the tally and exit (0 = green, 1 = any failure). We clear *hush*
+\\ first so the summary always prints and the exit code never depends on the
+\\ quiet flag's interaction with output on a particular Lisp (CLISP in
+\\ particular is sensitive here).
+\\ A machine-readable sentinel line is emitted alongside the human summary.
+\\ The exit CODE is the primary green/red signal on SBCL (the reference gate),
+\\ but the CLISP runtime can intermittently mis-report the exit code when its
+\\ buffered console stream races (cl.exit); its SUMMARY TEXT, by contrast, is
+\\ emitted reliably. Callers that need a CLISP/ECL parity signal therefore
+\\ grep for PORT-TESTS-PASS / PORT-TESTS-FAIL (see scripts/test-cli.sh).
+(define port-test-report
+  Name -> (let _ (set *hush* false)
+               Failures (value *port-test-failures*)
+               Total (value *port-test-count*)
+            (if (= Failures 0)
+                (do (output "~%~A: all ~A assertions passed.~%" Name Total)
+                    (output "PORT-TESTS-PASS ~A~%" Total)
+                    (cl.exit 0))
+                (do (output "~%~A: ~A of ~A assertions FAILED.~%" Name Failures Total)
+                    (output "PORT-TESTS-FAIL ~A~%" Failures)
+                    (cl.exit 1)))))


### PR DESCRIPTION
**Stacked on #59** (→ #60 → #58) — review only the 1 commit after `d444136`.

Bumps `KernelVersion` to [41.2](https://github.com/Shen-Language/shen-sources/releases/tag/shen-41.2) (StLib type-signature fixes, restored `programmable-pattern-matching` extension, extension test harness).

Verified against the 41.2 kernel on SBCL: `make precompile` → `make build-sbcl` → `make test-sbcl` (all 35 sections, 100%) → `make test-compiler` (all pass), plus the concurrency/threading and primitive-validation smoke tests from #59; binary reports kernel version 41.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
